### PR TITLE
Use permutations instead of combinations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+**/__pycache__/

--- a/notes.py
+++ b/notes.py
@@ -1,7 +1,7 @@
 #! /usr/bin/python
 import itertools
 from functools import total_ordering
-from itertools import combinations
+from itertools import permutations
 
 
 @total_ordering
@@ -54,7 +54,7 @@ class Chord:
             list(note.guitar_positions(valid_only=False).values())
             for note in self.notes
         ]
-        valid_combinations = combinations(range(len(TUNING)), len(self.notes))
+        valid_combinations = permutations(range(len(TUNING)), len(self.notes))
         valid_positions: list[tuple[dict[str, int], int]] = []
         for comb in valid_combinations:
             test_position = {
@@ -66,7 +66,12 @@ class Chord:
                 lowest_fret = min(f for f in test_position.values() if f != 0)
                 highest_fret = max(test_position.values())
                 fret_span = highest_fret - lowest_fret
-                valid_positions.append((test_position, fret_span))
+                test_position_sorted = {
+                    string: test_position[string]
+                    for string in string_names
+                    if string in test_position
+                }
+                valid_positions.append((test_position_sorted, fret_span))
         return [p for p, _ in sorted(valid_positions, key=lambda x: x[1])]
 
     def __repr__(self):

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,0 +1,13 @@
+import notes
+
+
+def test_positions_found_with_lower_notes_on_higher_strings() -> None:
+    chord = notes.Chord([
+        notes.Note('A', 2), notes.Note('C#', 3)
+    ])
+    expected = [
+        {'E': 9, 'A': 0},
+        {'E': 5, 'A': 4},
+    ]
+    actual = chord.guitar_positions()
+    assert actual == expected


### PR DESCRIPTION
At first I was trying to be efficient in searching for valid fingerings by always assuming that the lowest note of the chord would also be played on the lowest string (otherwise the fret span would be too large, right?!). However, there are reasonable fingerings that violate this constraint due to open strings. See the test example, where an `A3,C#4` triad can be played on the low E and low A strings on either the 5th and 4th frets, respectively, or the 9th and open.