### PR TITLE
Support other tunings

### DIFF
--- a/notes.py
+++ b/notes.py
@@ -53,6 +53,22 @@ class Note:
             or not valid_only
         }
 
+    @staticmethod
+    def from_semitones(semitones: int) -> 'Note':
+        octave = semitones // 12
+        remainder = semitones % 12
+        if remainder not in Note.SEMITONE_MAPPER.values():
+            remainder += 1
+            modifier = 'b'
+        else:
+            modifier = ''
+        inverse_mapper = {v: k for k, v in Note.SEMITONE_MAPPER.items()}
+        name = inverse_mapper[remainder] + modifier
+        return Note(name=name, octave=octave)
+
+    def add_semitones(self, semitones: int) -> 'Note':
+        return self.from_semitones(self.semitones + semitones)
+
     def __repr__(self):
         return self.simple_name + self.modifier + str(self.octave)
 
@@ -117,6 +133,7 @@ class Guitar:
         'B': Note('B', 3),
         'e': Note('E', 4),
     }
+
     def __init__(self, tuning: dict[any, 'Note'] = None, frets: int = 22):
         self.tuning = tuning or self.STANDARD_TUNING
         self.string_names = list(self.tuning.keys())

--- a/notes.py
+++ b/notes.py
@@ -6,36 +6,55 @@ from itertools import permutations
 
 @total_ordering
 class Note:
+
+    SEMITONE_MAPPER: dict[str, int] = {
+        'C': 0,
+        'D': 2,
+        'E': 4,
+        'F': 5,
+        'G': 7,
+        'A': 9,
+        'B': 11
+    }
+
+    MODIFIER_MAPPER: dict[str, int] = {
+        'bb': -2,
+        'b': -1,
+        '#': 1,
+        '##': 2,
+    }
+
     def __init__(self, name: str, octave: int):
-        self.name_simple, self.modifier = self.parse_name(name)
+        self.simple_name, self.modifier = self.parse_name(name)
         self.octave = octave
         self.semitones = (
                 12 * self.octave +
-                SEMITONE_MAPPER[self.name_simple] +
-                MODIFIER_MAPPER.get(self.modifier, 0)
+                self.SEMITONE_MAPPER[self.simple_name] +
+                self.MODIFIER_MAPPER.get(self.modifier, 0)
         )
 
     def parse_name(self, name: str) -> tuple[str, str]:
         assert len(name) <= 3
         simple_name = name[0].upper()
-        assert simple_name in SEMITONE_MAPPER.keys()
+        assert simple_name in self.SEMITONE_MAPPER.keys()
         if len(name) > 1:
             modifier = name[1:]
-            assert modifier in MODIFIER_MAPPER.keys()
+            assert modifier in self.MODIFIER_MAPPER.keys()
         else:
             modifier = ''
         return simple_name, modifier
 
-    def guitar_positions(self, valid_only: bool = True) -> dict[str, int]:
+    def guitar_positions(self, guitar: 'Guitar' = None, valid_only: bool = True) -> dict[any, int]:
+        guitar = guitar or Guitar()
         return {
             string: self.semitones - note.semitones
-            for string, note in TUNING.items()
-            if (valid_only and self >= note and (self.semitones - note.semitones) <= 22)
+            for string, note in guitar.tuning.items()
+            if (valid_only and self >= note and (self.semitones - note.semitones) <= guitar.frets)
             or not valid_only
         }
 
     def __repr__(self):
-        return self.name_simple + self.modifier + str(self.octave)
+        return self.simple_name + self.modifier + str(self.octave)
 
     def __eq__(self, other: 'Note'):
         return self.semitones == other.semitones
@@ -48,27 +67,38 @@ class Chord:
     def __init__(self, notes: list[Note]):
         self.notes = sorted(notes)
 
-    def guitar_positions(self) -> list[dict[str, int]]:
-        string_names = list(TUNING.keys())
+    def guitar_positions(self, guitar: 'Guitar' = None) -> list[dict[str, int]]:
+        guitar = guitar or Guitar()
+        # This is a list of lists
+        # The outer list has the length of the number of notes in the chord
+        # Each note has the length of the number of strings of the guitar,
+        # corresponding to the fret positions that note can be played on that string
         all_positions = [
-            list(note.guitar_positions(valid_only=False).values())
+            list(note.guitar_positions(guitar=guitar, valid_only=False).values())
             for note in self.notes
         ]
-        valid_combinations = permutations(range(len(TUNING)), len(self.notes))
+        # This gives all the permutations (n_strings P n_notes) of where the notes can be played on the strings
+        valid_combinations = permutations(range(len(guitar.tuning)), len(self.notes))
         valid_positions: list[tuple[dict[str, int], int]] = []
         for comb in valid_combinations:
             test_position = {
-                string_names[string]: all_positions[note][string]
+                guitar.string_names[string]: all_positions[note][string]
                 for note, string in enumerate(comb)
             }
-            if all(0 <= fret <= N_FRETS for fret in test_position.values()):
-                # Don't penalize open strings
-                lowest_fret = min(f for f in test_position.values() if f != 0)
-                highest_fret = max(test_position.values())
-                fret_span = highest_fret - lowest_fret
+            if all(0 <= fret <= guitar.frets for fret in test_position.values()):
+                if all(f == 0 for f in test_position.values()):
+                    fret_span = 0
+                else:
+                    # Don't penalize open strings
+                    lowest_fret = min(f for f in test_position.values() if f != 0)
+                    highest_fret = max(test_position.values())
+                    fret_span = highest_fret - lowest_fret
+                # Sort the position in order of the guitar strings
+                # (they will be out of order if a higher note appears on a lower string
+                # due to the ordering of `permutations`
                 test_position_sorted = {
                     string: test_position[string]
-                    for string in string_names
+                    for string in guitar.string_names
                     if string in test_position
                 }
                 valid_positions.append((test_position_sorted, fret_span))
@@ -78,30 +108,16 @@ class Chord:
         return ','.join(str(n) for n in self.notes)
 
 
-SEMITONE_MAPPER: dict[str, int] = {
-    'C': 0,
-    'D': 2,
-    'E': 4,
-    'F': 5,
-    'G': 7,
-    'A': 9,
-    'B': 11
-}
-
-MODIFIER_MAPPER: dict[str, int] = {
-    'bb': -2,
-    'b': -1,
-    '#': 1,
-    '##': 2,
-}
-
-N_FRETS = 22
-
-TUNING: dict[str, 'Note'] = {
-    'E': Note('E', 2),
-    'A': Note('A', 2),
-    'D': Note('D', 3),
-    'G': Note('G', 3),
-    'B': Note('B', 3),
-    'e': Note('E', 4),
-}
+class Guitar:
+    STANDARD_TUNING: dict[str, 'Note'] = {
+        'E': Note('E', 2),
+        'A': Note('A', 2),
+        'D': Note('D', 3),
+        'G': Note('G', 3),
+        'B': Note('B', 3),
+        'e': Note('E', 4),
+    }
+    def __init__(self, tuning: dict[any, 'Note'] = None, frets: int = 22):
+        self.tuning = tuning or self.STANDARD_TUNING
+        self.string_names = list(self.tuning.keys())
+        self.frets = frets

--- a/notes.py
+++ b/notes.py
@@ -134,7 +134,9 @@ class Guitar:
         'e': Note('E', 4),
     }
 
-    def __init__(self, tuning: dict[any, 'Note'] = None, frets: int = 22):
+    def __init__(self, tuning: dict[any, 'Note'] = None, frets: int = 22, capo: int = 0):
         self.tuning = tuning or self.STANDARD_TUNING
+        self.capo = capo
+        self.tuning = {name: note.add_semitones(capo) for name, note in self.tuning.items()}
         self.string_names = list(self.tuning.keys())
         self.frets = frets

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -62,11 +62,13 @@ def test_guitar_with_different_fret_count(frets: int, expected: dict[str, int]) 
         [('B', 1), ('E', 2), ('A', 2), ('D', 3), ('G', 3), ('B', 3), ('E', 4), ('A', 4)],
     ]
 )
-def test_different_guitar_tunings(strings: list[tuple[str, int]]) -> None:
+@pytest.mark.parametrize('capo', [0, 2, 10])
+def test_different_guitar_tunings(strings: list[tuple[str, int]], capo: int) -> None:
     guitar = notes.Guitar(
-        tuning={i: notes.Note(*string) for i, string in enumerate(strings)}
+        tuning={i: notes.Note(*string) for i, string in enumerate(strings)},
+        capo=capo
     )
-    chord = notes.Chord([notes.Note(*string) for string in strings])
+    chord = notes.Chord([notes.Note(*string).add_semitones(capo) for string in strings])
     expected = [{i: 0 for i in range(len(strings))}]
     acutal = chord.guitar_positions(guitar=guitar)
     assert acutal == expected

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,3 +1,5 @@
+import pytest
+
 import notes
 
 
@@ -11,3 +13,34 @@ def test_positions_found_with_lower_notes_on_higher_strings() -> None:
     ]
     actual = chord.guitar_positions()
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'frets,expected',
+    [
+        (10, {'E': 8, 'A': 3}),
+        (5, {'A': 3})
+    ]
+)
+def test_guitar_with_different_fret_count(frets: int, expected: dict[str, int]) -> None:
+    guitar = notes.Guitar(frets=frets)
+    note = notes.Note('C', 3)
+    actual = note.guitar_positions(guitar)
+    assert actual == expected
+
+@pytest.mark.parametrize(
+    'strings',
+    [
+        [('E', 2), ('A', 2), ('D', 3), ('G', 3), ('B', 3), ('E', 4)],
+        [('D', 2), ('A', 2), ('D', 3), ('G', 3), ('A', 3), ('D', 4)],
+        [('B', 1), ('E', 2), ('A', 2), ('D', 3), ('G', 3), ('B', 3), ('E', 4), ('A', 4)],
+    ]
+)
+def test_different_guitar_tunings(strings: list[tuple[str, int]]) -> None:
+    guitar = notes.Guitar(
+        tuning={i: notes.Note(*string) for i, string in enumerate(strings)}
+    )
+    chord = notes.Chord([notes.Note(*string) for string in strings])
+    expected = [{i: 0 for i in range(len(strings))}]
+    acutal = chord.guitar_positions(guitar=guitar)
+    assert acutal == expected

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -3,6 +3,32 @@ import pytest
 import notes
 
 
+@pytest.mark.parametrize(
+    'semitones,expected',
+    [
+        (0, notes.Note('C', 0)),
+        (12, notes.Note('C', 1)),
+        (39, notes.Note('Eb', 3)),
+    ]
+)
+def test_note_from_semitones(semitones: int, expected: notes.Note) -> None:
+    actual = notes.Note.from_semitones(semitones=semitones)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'semitones,expected',
+    [
+        (0, notes.Note('C', 3)),
+        (12, notes.Note('C', 4)),
+        (8, notes.Note('Ab', 3)),
+    ]
+)
+def test_add_semitones(semitones: int, expected: notes.Note) -> None:
+    actual = notes.Note('C', 3).add_semitones(semitones)
+    assert actual == expected
+
+
 def test_positions_found_with_lower_notes_on_higher_strings() -> None:
     chord = notes.Chord([
         notes.Note('A', 2), notes.Note('C#', 3)


### PR DESCRIPTION
This adds a `Guitar` method to support other tunings, including inclusion of a capo. E.g., for a guitar in open D tuning with a capo on the first fret, you would expect the only way to play an Eb2 would be open (relative to the capo) on the lowest string:

```python
open_d_tuning = {
    6: notes.Note('D', 2),
    5: notes.Note('A', 2),
    4: notes.Note('D', 3),
    3: notes.Note('F#', 3),
    2: notes.Note('A', 3),
    1: notes.Note('D', 4),

}
guitar = notes.Guitar(open_d_tuning, capo=1)
notes.Note('Eb', 0).guitar_positions(guitar=guitar)
# {6: 0}
```