### PR TITLE
Fix valid positions for high frets with capo

### DIFF
--- a/notes.py
+++ b/notes.py
@@ -139,4 +139,4 @@ class Guitar:
         self.capo = capo
         self.tuning = {name: note.add_semitones(capo) for name, note in self.tuning.items()}
         self.string_names = list(self.tuning.keys())
-        self.frets = frets
+        self.frets = frets - capo

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -72,3 +72,9 @@ def test_different_guitar_tunings(strings: list[tuple[str, int]], capo: int) -> 
     expected = [{i: 0 for i in range(len(strings))}]
     acutal = chord.guitar_positions(guitar=guitar)
     assert acutal == expected
+
+
+def test_validity_of_high_frets_with_capo() -> None:
+    guitar = notes.Guitar(frets=5, capo=4)
+    assert notes.Note('A', 2).guitar_positions(guitar, valid_only=True) == {'E': 1}
+    assert notes.Note('A#', 2).guitar_positions(guitar, valid_only=True) == {}


### PR DESCRIPTION
When capo was added, some positions on higher frets can become invalid (the number of frets doesn't increase when you add a capo) so to fix we decrease the number of _effective_ frets.