### PR TITLE
Add a web app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,23 @@
+import notes
+
+from flask import Flask, render_template
+from markupsafe import escape
+
+
+app = Flask(__name__)
+
+
+@app.route("/demo")
+def info():
+    return render_template('info.html')
+
+
+@app.route("/demo/<notes_string>/<int:top_n>/")
+def demo(notes_string: str, top_n: int) -> str:
+    notes_list = [notes.Note.from_string(note) for note in escape(notes_string).split(',')]
+    chord = notes.Chord(notes_list)
+    positions = chord.guitar_positions()[:top_n]
+    return render_template(
+        'demo.html',
+        chord=chord, top_n=top_n, positions=positions
+    )

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: music
+channels:
+  - defaults
+dependencies:
+  - python
+  - flask
+  - pytest

--- a/notes.py
+++ b/notes.py
@@ -22,6 +22,8 @@ class Note:
         'b': -1,
         '#': 1,
         '##': 2,
+        's': 1,
+        'ss': 2,
     }
 
     def __init__(self, name: str, octave: int):
@@ -65,6 +67,10 @@ class Note:
         inverse_mapper = {v: k for k, v in Note.SEMITONE_MAPPER.items()}
         name = inverse_mapper[remainder] + modifier
         return Note(name=name, octave=octave)
+
+    @staticmethod
+    def from_string(note: str) -> 'Note':
+        return Note(note[:-1], int(note[-1]))
 
     def add_semitones(self, semitones: int) -> 'Note':
         return self.from_semitones(self.semitones + semitones)

--- a/templates/demo.html
+++ b/templates/demo.html
@@ -1,0 +1,14 @@
+{% extends "info.html" %}
+
+{% block content %}
+
+<p>The chord you entered was: {{ chord }}</p>
+<p>The top {{ top_n }} fingerings for that chord are:</p>
+
+<ul>
+{% for position in positions %}
+  <li>{{ position }}</li>
+{% endfor %}
+</ul>
+
+{% endblock %}

--- a/templates/info.html
+++ b/templates/info.html
@@ -1,0 +1,13 @@
+<!doctype html>
+
+<head>
+    <title>Guitar Position Demo</title>
+</head>
+
+<h1>Guitar Position Demo</h1>
+
+<p>This demo gives guitar fingerings for any chord</p>
+
+{% block content %}
+
+{% endblock %}

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -17,6 +17,33 @@ def test_note_from_semitones(semitones: int, expected: notes.Note) -> None:
 
 
 @pytest.mark.parametrize(
+    'name,expected',
+    [
+        ('C0', notes.Note('C', 0)),
+        ('C1', notes.Note('C', 1)),
+        ('Eb3', notes.Note('Eb', 3)),
+        ('Ebb3', notes.Note('Ebb', 3)),
+    ]
+)
+def test_note_from_string(name: str, expected: notes.Note) -> None:
+    actual = notes.Note.from_string(note=name)
+    assert actual == expected
+
+
+def test_both_sharps_work() -> None:
+    assert (
+        notes.Note('F#', 3) ==
+        notes.Note('Fs', 3) ==
+        notes.Note('Gb', 3)
+    )
+    assert (
+        notes.Note('C##', 2) ==
+        notes.Note('Css', 2) ==
+        notes.Note('D', 2)
+    )
+
+
+@pytest.mark.parametrize(
     'semitones,expected',
     [
         (0, notes.Note('C', 3)),


### PR DESCRIPTION
This adds a basic web app to serve results of the fingering position calculator.

Run the web app with `flask run`

To view the app, go to  `http://<ip.address.of.host>:5000/demo`

To make a request, change the URL to `demo/<chord_notes>/<top_n_positions>`. E.g., `demo/C3,G3,E4/6`

Note, since `#` isn't allowed in URLs, you must encode this as `%23`. To work around this, I updated the calculator to accept `s` for sharps (e.g. `Gs3`)

