### PR TITLE
Add support for specifying chord by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ Classes include:
 
 ## Demo
 
-There is a `demo.py` script that will generate guitar chord positions. E.g.:
+There is a `demo.py` script that will generate guitar chord positions. See `--help` for more info on the args.
+
+### `notes` Mode
+
+In `notes` mode, you must specify the notes (including octave) that you want as a comma-separated string:
 
 ```commandline
 $ python demo.py --notes C3,G3,E4,Bb4 --top_n 3
@@ -23,6 +27,23 @@ Here are the top 3 guitar positions for the chord: C3,G3,E4,Bb4
 {'E': 8, 'A': 10, 'B': 11, 'e': 0}
 {'E': 8, 'D': 5, 'B': 5, 'e': 6}
 ```
+
+### `name` Mode
+
+In `name` mode, you can just pass a chord name (e.g., `Bbmaj7`). 
+Currently, only close root position (with root lowest possible for the guitar tuning) is supported.
+
+```commandline
+$ python demo.py --name C7 --top_n 3   
+C3,E3,G3,Bb3
+Here are the top 3 guitar positions for the chord: C3,E3,G3,Bb3 with a guitar tuned to: {'E': E2, 'A': A2, 'D': D3, 'G': G3, 'B': B3, 'e': E4}
+{'E': 8, 'A': 7, 'D': 8, 'G': 0}
+{'E': 8, 'A': 7, 'D': 5, 'G': 3}
+{'E': 8, 'A': 10, 'D': 2, 'G': 3}
+
+```
+
+### Other features
 
 You can use the `--graphical` (`-g`) flag for ASCII art:
 

--- a/app.py
+++ b/app.py
@@ -13,16 +13,21 @@ app.config['SECRET_KEY'] = os.urandom(24).hex()
 @app.route("/", methods=('GET', 'POST'))
 def input():
     if request.method == 'POST':
-        notes_string = request.form['notes']
-        top_n = request.form['top_n'] or 5
+        guitar = notes.Guitar(notes.Guitar.parse_tuning(request.form['tuning']))
         tuning = (
             request.form['tuning'] or
             str({string: str(note) for string, note in notes.Guitar.STANDARD_TUNING.items()})
         )
+        top_n = request.form['top_n'] or 5
+        notes_string = request.form['notes']
+        chord_name = request.form['chord_name']
         if not notes_string:
-            flash('Notes are required!')
-        else:
-            return redirect(url_for('display', notes_string=notes_string, top_n=top_n, tuning=tuning))
+            if not chord_name:
+                flash('Either notes or name are required!')
+            else:
+                chord = notes.ChordName(chord_name).get_chord(lower=guitar.lowest)
+                notes_string = str(chord)
+        return redirect(url_for('display', notes_string=notes_string, top_n=top_n, tuning=tuning))
     return render_template('input.html')
 
 

--- a/demo.py
+++ b/demo.py
@@ -4,10 +4,15 @@ import notes
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description='Given a chord from a set of notes, show the corresponding guitar positions',
+        description='Given a chord, show the corresponding guitar positions',
     )
     parser.add_argument(
-        '--notes', type=str, required=True, help='A comma separated list of notes, e.g. `C3,G3,Eb4`'
+        '--notes', type=str, help='A comma separated list of notes, e.g. `C3,G3,Eb4`'
+    )
+    parser.add_argument(
+        '--name', type=str,
+        help='A chord name, like Bbmaj7; currently gives a chord in close root position '
+             'with lowest possible root for guitar tuning'
     )
     parser.add_argument(
         '--top_n', type=int, default=5, help='How many positions to return'
@@ -27,9 +32,15 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    note_list = [notes.Note.from_string(note) for note in args.notes.split(',')]
-    chord = notes.Chord(note_list)
     guitar = notes.Guitar(tuning=args.tuning, capo=args.capo, frets=args.frets)
+    if args.notes:
+        note_list = [notes.Note.from_string(note) for note in args.notes.split(',')]
+        chord = notes.Chord(note_list)
+    elif args.name:
+        chord = notes.ChordName(args.name).get_chord(lower=guitar.lowest)
+        print(chord)
+    else:
+        raise ValueError('Either `notes` or `name` is required')
     positions = chord.guitar_positions(guitar=guitar)[:args.top_n]
     print(f'Here are the top {args.top_n} guitar positions for the chord: {chord} with a guitar tuned to: {guitar}')
     for p in positions:

--- a/notes.py
+++ b/notes.py
@@ -1,6 +1,6 @@
 #! /usr/bin/python
 from functools import total_ordering
-from itertools import permutations
+from itertools import permutations, product
 import json
 from typing import Hashable
 
@@ -20,19 +20,25 @@ class Note:
     MODIFIER_MAPPER: dict[str, int] = {
         'bb': -2,
         'b': -1,
+        '': 0,
         '#': 1,
         '##': 2,
         's': 1,
         'ss': 2,
     }
 
+    ALL_NOTES_NAMES = [
+        name + mod for name, mod in product(SEMITONE_MAPPER.keys(), MODIFIER_MAPPER.keys())
+    ]
+
     def __init__(self, name: str, octave: int):
         self.simple_name, self.modifier = self.parse_name(name)
+        self.name = name
         self.octave = octave
         self.semitones = (
                 12 * self.octave +
                 self.SEMITONE_MAPPER[self.simple_name] +
-                self.MODIFIER_MAPPER.get(self.modifier, 0)
+                self.MODIFIER_MAPPER[self.modifier]
         )
 
     def parse_name(self, name: str) -> tuple[str, str]:
@@ -115,6 +121,54 @@ class Chord:
 
     def __repr__(self):
         return ','.join(str(n) for n in self.notes)
+
+    def __eq__(self, other):
+        return (
+            (len(self.notes) == len(other.notes)) and
+            all(s == o for s, o in zip(self.notes, other.notes))
+        )
+
+
+class ChordName:
+
+    QUALITY_SEMITONE_MAPPER = {
+        '': [0, 4, 7],
+        'm': [0, 3, 7],
+        'dim': [0, 3, 6],
+        'aug': [0, 4, 8],
+        'maj7': [0, 4, 7, 11],
+        '7': [0, 4, 7, 10],
+        'm7': [0, 3, 7, 10],
+        'm7b5': [0, 3, 6, 10],
+        'dim7': [0, 3, 6, 9],
+        'aug7': [0, 4, 8, 11],
+    }
+
+    def __init__(self, chord_name: str):
+        chord_note = None
+        for note_name in Note.ALL_NOTES_NAMES:
+            if chord_name.startswith(note_name):
+                chord_note = note_name
+                break
+        if chord_note is None:
+            raise ValueError(f'Invalid chord name; must start with one of {Note.ALL_NOTES_NAMES}')
+        if '/' in chord_name:
+            chord_name, root = chord_name.split('/')
+        else:
+            root = chord_note
+        quality = chord_name.replace(chord_note, '')
+        self.chord_note = chord_note
+        self.root = root
+        self.quality = quality
+
+    def get_chord(self, lower: 'Note' = Note('C', 0)) -> 'Chord':
+        root_note = lower
+        for s in range(12):
+            root_note = root_note.add_semitones(s)
+            if root_note.name == self.chord_note:
+                break
+        notes = [root_note.add_semitones(s) for s in self.QUALITY_SEMITONE_MAPPER[self.quality]]
+        return Chord(notes)
 
 
 class GuitarPosition:

--- a/notes.py
+++ b/notes.py
@@ -2,7 +2,7 @@
 from functools import total_ordering
 from itertools import permutations, product
 import json
-from typing import Hashable
+from typing import Hashable, Optional
 
 @total_ordering
 class Note:
@@ -252,8 +252,11 @@ class Guitar:
         return str(self.tuning)
 
     @staticmethod
-    def parse_tuning(tuning: str) -> dict[str, 'Note']:
-        return {
-            string: Note.from_string(note)
-            for string, note in json.loads(tuning.replace("'", '"')).items()
-        }
+    def parse_tuning(tuning: Optional[str] = None) -> dict[str, 'Note']:
+        if not tuning:
+            return Guitar.STANDARD_TUNING
+        else:
+            return {
+                string: Note.from_string(note)
+                for string, note in json.loads(tuning.replace("'", '"')).items()
+            }

--- a/templates/input.html
+++ b/templates/input.html
@@ -2,12 +2,21 @@
 
 {% block content %}
     <h2>{% block title %} User Input {% endblock %}</h2>
+    <p>Enter either a set of notes (comma separated with octave) or a chord name<br>
+    (note, chord name currently only supports close root position)</p>
     <form method="post">
         <label for="title">Chord Notes</label>
         <br>
         <input type="text" name="notes"
                placeholder="C3,G3,E4,Bb4"
                value="{{ request.form['notes'] }}"></input>
+        <br>
+        <br>
+        <label for="title">Chord Name</label>
+        <br>
+        <input type="text" name="chord_name"
+               placeholder="C7"
+               value="{{ request.form['chord_name'] }}"></input>
         <br>
         <br>
         <label for="title">Number of Positions (default 5)</label>

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -56,6 +56,21 @@ def test_add_semitones(semitones: int, expected: notes.Note) -> None:
     assert actual == expected
 
 
+@pytest.mark.parametrize(
+    'self,other',
+    [
+        (('C', 0), ('C', 0)),
+        (('C', 0), ('C', 1)),
+        (('C', 10), ('C', -3)),
+        (('F#', 0), ('Gb', 0)),
+        (('F#', 0), ('Gb', 3)),
+        (('C##', 3), ('D', 0)),
+    ]
+)
+def test_same_name(self, other) -> None:
+    assert notes.Note(*self).same_name(notes.Note(*other))
+
+
 def test_positions_found_with_lower_notes_on_higher_strings() -> None:
     chord = notes.Chord([
         notes.Note('A', 2), notes.Note('C#', 3)
@@ -99,6 +114,15 @@ def test_different_guitar_tunings(strings: list[tuple[str, int]], capo: int) -> 
     expected = {i: 0 for i in range(len(strings))}
     actual = chord.guitar_positions(guitar=guitar)[0].positions_dict
     assert actual == expected
+
+
+def test_guitar_extremes() -> None:
+    guitar = notes.Guitar(
+        tuning={'E': notes.Note('E', 2), 'A': notes.Note('A', 2)},
+        frets=3
+    )
+    assert guitar.lowest == notes.Note('E', 2)
+    assert guitar.highest == notes.Note('C', 3)
 
 
 def test_validity_of_high_frets_with_capo() -> None:
@@ -189,4 +213,14 @@ def test_chord_name_to_chord(name: str, expected: list) -> None:
     chord_name = notes.ChordName(name)
     expected = notes.Chord([notes.Note(*n) for n in expected])
     actual = chord_name.get_chord()
+    assert actual == expected
+
+
+def test_chord_name_to_chord_different_lower() -> None:
+    actual = notes.ChordName('C').get_chord(lower=notes.Note('E', 2))
+    expected = notes.Chord([
+        notes.Note('C', 3),
+        notes.Note('E', 3),
+        notes.Note('G', 3),
+    ])
     assert actual == expected

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -156,3 +156,37 @@ def test_parse_tuning(string: str) -> None:
         "A": notes.Note('A', 2)
     }
     assert notes.Guitar.parse_tuning(string) == expected
+
+
+@pytest.mark.parametrize(
+    'name,expected',
+    [
+        ('C', {'chord_note': 'C', 'root': 'C', 'quality': ''}),
+        ('Bbmaj7/D', {'chord_note': 'Bb', 'root': 'D', 'quality': 'maj7'}),
+    ]
+)
+def test_chord_name(name: str, expected: dict) -> None:
+    chord_name = notes.ChordName(name)
+    assert chord_name.root == expected['root']
+    assert chord_name.chord_note == expected['chord_note']
+    assert chord_name.quality == expected['quality']
+
+
+def test_chord_name_error() -> None:
+    with pytest.raises(ValueError):
+        notes.ChordName('Hb7')
+
+
+@pytest.mark.parametrize(
+    'name,expected',
+    [
+        ('C', [('C', 0), ('E', 0), ('G', 0)]),
+        ('C7', [('C', 0), ('E', 0), ('G', 0), ('Bb', 0)]),
+        ('Bbmaj7/D', [('Bb', 0), ('D', 1), ('F', 1), ('A', 1)]),
+    ]
+)
+def test_chord_name_to_chord(name: str, expected: list) -> None:
+    chord_name = notes.ChordName(name)
+    expected = notes.Chord([notes.Note(*n) for n in expected])
+    actual = chord_name.get_chord()
+    assert actual == expected

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -147,7 +147,7 @@ def test_print_more_complex() -> None:
     [
         '{"E": "E2", "A": "A2"}',
         "{'E': 'E2', 'A': 'A2'}",
-        str({"E": notes.Note('E', 2), "A": notes.Note('A', 2)}),
+        str({"E": str(notes.Note('E', 2)), "A": str(notes.Note('A', 2))}),
     ]
 )
 def test_parse_tuning(string: str) -> None:


### PR DESCRIPTION
This adds the ability to specify a chord by name, e.g. `Cmaj7` instead of by note. For now, this just supports close root position. It also adds a `ChordName` class to help with this.