### PR TITLE
Allow inversions

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ def input():
             if not chord_name:
                 flash('Either notes or name are required!')
             else:
-                chord = notes.ChordName(chord_name).get_chord(lower=guitar.lowest)
+                chord = notes.ChordName(chord_name).get_close_chord(lower=guitar.lowest)
                 notes_string = str(chord)
         return redirect(url_for('display', notes_string=notes_string, top_n=top_n, tuning=tuning))
     return render_template('input.html')

--- a/demo.py
+++ b/demo.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         note_list = [notes.Note.from_string(note) for note in args.notes.split(',')]
         chord = notes.Chord(note_list)
     elif args.name:
-        chord = notes.ChordName(args.name).get_chord(lower=guitar.lowest)
+        chord = notes.ChordName(args.name).get_close_chord(lower=guitar.lowest)
         print(chord)
     else:
         raise ValueError('Either `notes` or `name` is required')

--- a/notes.py
+++ b/notes.py
@@ -85,6 +85,18 @@ class Note:
     def same_name(self, other) -> bool:
         return self.semitones % 12 == other.semitones % 12
 
+    def nearest_above(self, note: str, allow_equal: bool = True) -> 'Note':
+        interval = (Note(note, 0).semitones - self.semitones) % 12
+        if not allow_equal and interval == 0:
+            interval = 12
+        return self.add_semitones(interval)
+
+    def nearest_below(self, note: str, allow_equal: bool = True) -> 'Note':
+        interval = (self.semitones - Note(note, 0).semitones) % 12
+        if not allow_equal and interval == 0:
+            interval = 12
+        return self.add_semitones(-interval)
+
     def __repr__(self):
         return str(self.simple_name + self.modifier + str(self.octave))
 
@@ -170,13 +182,7 @@ class ChordName:
         """
         # Note, this doesn't actually respect the root note yet
         chord_note_ref = Note(self.chord_note, octave=0)
-        root_note = lower
-        for s in range(12):
-            root_note = lower.add_semitones(s)
-            if chord_note_ref.same_name(root_note):
-                break
-            elif s == 11:
-                raise ValueError("This shouldn't be possible!")
+        root_note = lower.nearest_above(self.chord_note)
         notes = [root_note.add_semitones(s) for s in self.QUALITY_SEMITONE_MAPPER[self.quality]]
         return Chord(notes)
 

--- a/notes.py
+++ b/notes.py
@@ -138,7 +138,7 @@ class Chord:
     def __repr__(self):
         return ','.join(str(n) for n in self.notes)
 
-    def __eq__(self, other):
+    def __eq__(self, other: 'Chord'):
         return (
             (len(self.notes) == len(other.notes)) and
             all(s == o for s, o in zip(self.notes, other.notes))
@@ -183,28 +183,27 @@ class ChordName:
         self.chord_note = chord_note
         self.root = root
         self.quality = quality
-        self.notes = [
+        self.note_names = [
             Note(self.chord_note, octave=0).add_semitones(s, bias=self.KEY_BIAS[self.chord_note]).name
             for s in self.QUALITY_SEMITONE_MAPPER[self.quality]
         ]
         root_index = None
-        for ind, note in enumerate(self.notes):
+        for ind, note in enumerate(self.note_names):
             if Note(note, 0).same_name(Note(self.root, 0)):
                 root_index = ind
         if root_index is not None:
-            self.notes = _rotate_list(self.notes, root_index)
+            self.note_names = _rotate_list(self.note_names, root_index)
         else:
-            self.notes.insert(0, self.root)
-
+            self.note_names.insert(0, self.root)
 
     def get_chord(self, lower: 'Note' = Note('C', 0)) -> 'Chord':
         """
-        For a chord name, return the `Chord` in close root position whose root is the lowest note >= `lower`
+        For a chord name, return the `Chord` in close position whose root is the lowest note >= `lower`
         """
-        # Note, this doesn't actually respect the root note yet
-        chord_note_ref = Note(self.chord_note, octave=0)
-        root_note = lower.nearest_above(self.chord_note)
-        notes = [root_note.add_semitones(s) for s in self.QUALITY_SEMITONE_MAPPER[self.quality]]
+        notes = []
+        for note_name in self.note_names:
+            notes.append(lower.nearest_above(note_name))
+            lower = notes[-1]
         return Chord(notes)
 
 

--- a/notes.py
+++ b/notes.py
@@ -196,7 +196,7 @@ class ChordName:
         else:
             self.note_names.insert(0, self.root)
 
-    def get_chord(self, lower: 'Note' = Note('C', 0)) -> 'Chord':
+    def get_close_chord(self, *, lower: 'Note' = Note('C', 0)) -> 'Chord':
         """
         For a chord name, return the `Chord` in close position whose root is the lowest note >= `lower`
         """
@@ -205,6 +205,20 @@ class ChordName:
             notes.append(lower.nearest_above(note_name))
             lower = notes[-1]
         return Chord(notes)
+
+    def get_all_chords(self, *, lower: 'Note' = Note('C', 0), upper: 'Note') -> list['Chord']:
+        """
+        For a chord name, return all `Chord`s that can fit between `lower` and `upper`
+        """
+
+        def _is_valid(notes: list[Note]) -> bool:
+            return (
+                all(lower <= note <= upper for note in notes) and
+                (notes[0] < other for other in notes[1:])
+            )
+
+        chord_list = []
+        return chord_list
 
 
 class GuitarPosition:

--- a/notes.py
+++ b/notes.py
@@ -157,7 +157,7 @@ class ChordName:
         'm7': [0, 3, 7, 10],
         'm7b5': [0, 3, 6, 10],
         'dim7': [0, 3, 6, 9],
-        'aug7': [0, 4, 8, 11],
+        'aug7': [0, 4, 8, 10],
     }
     FLAT_KEYS = ['C', 'F', 'Bb', 'Eb', 'Ab', 'Db', 'Gb', 'Cb', 'Fb', 'Bbb', 'Ebb', 'Abb', 'Dbb']
     SHARP_KEYS = ['G', 'D', 'A', 'E', 'B', 'F#', 'C#', 'G#', 'D#', 'A#', 'E#', 'B#', 'F##']
@@ -187,8 +187,12 @@ class ChordName:
             Note(self.chord_note, octave=0).add_semitones(s, bias=self.KEY_BIAS[self.chord_note]).name
             for s in self.QUALITY_SEMITONE_MAPPER[self.quality]
         ]
-        if self.root in self.notes:
-            self.notes = _rotate_list(self.notes, self.notes.index(self.root))
+        root_index = None
+        for ind, note in enumerate(self.notes):
+            if Note(note, 0).same_name(Note(self.root, 0)):
+                root_index = ind
+        if root_index is not None:
+            self.notes = _rotate_list(self.notes, root_index)
         else:
             self.notes.insert(0, self.root)
 

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -224,3 +224,33 @@ def test_chord_name_to_chord_different_lower() -> None:
         notes.Note('G', 3),
     ])
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'note,other,allow_equal,octave',
+    [
+        (('C', 3), 'E', True, 3),
+        (('C', 3), 'C', True, 3),
+        (('C', 3), 'C', False, 4),
+        (('G', 3), 'D', True, 4),
+    ]
+)
+def test_nearest_above(note: tuple[str, int], other: str, allow_equal: bool, octave: int) -> None:
+    expected = notes.Note(other, octave)
+    actual = notes.Note(*note).nearest_above(other, allow_equal=allow_equal)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'note,other,allow_equal,octave',
+    [
+        (('C', 3), 'E', True, 2),
+        (('C', 3), 'C', True, 3),
+        (('C', 3), 'C', False, 2),
+        (('G', 3), 'D', True, 3),
+    ]
+)
+def test_nearest_above(note: tuple[str, int], other: str, allow_equal: bool, octave: int) -> None:
+    expected = notes.Note(other, octave)
+    actual = notes.Note(*note).nearest_below(other, allow_equal=allow_equal)
+    assert actual == expected

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -215,7 +215,7 @@ def test_chord_name(name: str, expected: dict) -> None:
     assert chord_name.root == expected['root']
     assert chord_name.chord_note == expected['chord_note']
     assert chord_name.quality == expected['quality']
-    assert chord_name.notes == expected['notes']
+    assert chord_name.note_names == expected['notes']
 
 
 def test_chord_name_error() -> None:
@@ -228,7 +228,7 @@ def test_chord_name_error() -> None:
     [
         ('C', [('C', 0), ('E', 0), ('G', 0)]),
         ('C7', [('C', 0), ('E', 0), ('G', 0), ('Bb', 0)]),
-        ('Bbmaj7/D', [('Bb', 0), ('D', 1), ('F', 1), ('A', 1)]),
+        ('Bbmaj7/D', [('D', 0), ('F', 0), ('A', 0), ('Bb', 0)]),
     ]
 )
 def test_chord_name_to_chord(name: str, expected: list) -> None:

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -186,12 +186,28 @@ def test_parse_tuning(string: str) -> None:
 @pytest.mark.parametrize(
     'name,expected',
     [
+        # TODO: this gets some enharmonics wrong, but it shouldn't double count the root note at least
+        # all qualities
         ('C', {'chord_note': 'C', 'root': 'C', 'quality': '', 'notes': ['C', 'E', 'G']}),
-        ('Bbmaj7/D', {'chord_note': 'Bb', 'root': 'D', 'quality': 'maj7', 'notes': ['D', 'F', 'A', 'Bb']}),
-        ('C/D', {'chord_note': 'C', 'root': 'D', 'quality': '', 'notes': ['D', 'C', 'E', 'G']}),
+        ('Cm', {'chord_note': 'C', 'root': 'C', 'quality': 'm', 'notes': ['C', 'Eb', 'G']}),
+        ('Cdim', {'chord_note': 'C', 'root': 'C', 'quality': 'dim', 'notes': ['C', 'Eb', 'Gb']}),
+        ('Caug', {'chord_note': 'C', 'root': 'C', 'quality': 'aug', 'notes': ['C', 'E', 'Ab']}),
+        ('Cmaj7', {'chord_note': 'C', 'root': 'C', 'quality': 'maj7', 'notes': ['C', 'E', 'G', 'B']}),
+        ('C7', {'chord_note': 'C', 'root': 'C', 'quality': '7', 'notes': ['C', 'E', 'G', 'Bb']}),
+        ('Cm7', {'chord_note': 'C', 'root': 'C', 'quality': 'm7', 'notes': ['C', 'Eb', 'G', 'Bb']}),
+        ('Cm7b5', {'chord_note': 'C', 'root': 'C', 'quality': 'm7b5', 'notes': ['C', 'Eb', 'Gb', 'Bb']}),
+        ('Cdim7', {'chord_note': 'C', 'root': 'C', 'quality': 'dim7', 'notes': ['C', 'Eb', 'Gb', 'A']}),
+        ('Caug7', {'chord_note': 'C', 'root': 'C', 'quality': 'aug7', 'notes': ['C', 'E', 'Ab', 'Bb']}),
+        # other keys
         ('F#', {'chord_note': 'F#', 'root': 'F#', 'quality': '', 'notes': ['F#', 'A#', 'C#']}),
-        # TODO: Fix this?
-        ('Gm/Bb', {'chord_note': 'G', 'root': 'Bb', 'quality': 'm', 'notes': ['Bb', 'D', 'G']}),
+        ('F#m7b5', {'chord_note': 'F#', 'root': 'F#', 'quality': 'm7b5', 'notes': ['F#', 'A', 'C', 'E']}),
+        # inversions
+        ('Bbmaj7/D', {'chord_note': 'Bb', 'root': 'D', 'quality': 'maj7', 'notes': ['D', 'F', 'A', 'Bb']}),
+        ('F#m7b5/E', {'chord_note': 'F#', 'root': 'E', 'quality': 'm7b5', 'notes': ['E', 'F#', 'A', 'C']}),
+        ('C/D', {'chord_note': 'C', 'root': 'D', 'quality': '', 'notes': ['D', 'C', 'E', 'G']}),
+        ('C/C', {'chord_note': 'C', 'root': 'C', 'quality': '', 'notes': ['C', 'E', 'G']}),
+        ('Gm/Bb', {'chord_note': 'G', 'root': 'Bb', 'quality': 'm', 'notes': ['A#', 'D', 'G']}),
+        ('Gm/A#', {'chord_note': 'G', 'root': 'A#', 'quality': 'm', 'notes': ['A#', 'D', 'G']}),
     ]
 )
 def test_chord_name(name: str, expected: dict) -> None:

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -251,30 +251,30 @@ def test_chord_name_to_chord_different_lower() -> None:
 @pytest.mark.parametrize(
     'note,other,allow_equal,octave',
     [
-        (('C', 3), 'E', True, 3),
-        (('C', 3), 'C', True, 3),
-        (('C', 3), 'C', False, 4),
-        (('G', 3), 'D', True, 4),
+        (notes.Note('C', 3), 'E', True, 3),
+        (notes.Note('C', 3), 'C', True, 3),
+        (notes.Note('C', 3), 'C', False, 4),
+        (notes.Note('G', 3), 'D', True, 4),
     ]
 )
-def test_nearest_above(note: tuple[str, int], other: str, allow_equal: bool, octave: int) -> None:
+def test_nearest_above(note: notes.Note, other: str, allow_equal: bool, octave: int) -> None:
     expected = notes.Note(other, octave)
-    actual = notes.Note(*note).nearest_above(other, allow_equal=allow_equal)
+    actual = note.nearest_above(other, allow_equal=allow_equal)
     assert actual == expected
 
 
 @pytest.mark.parametrize(
     'note,other,allow_equal,octave',
     [
-        (('C', 3), 'E', True, 2),
-        (('C', 3), 'C', True, 3),
-        (('C', 3), 'C', False, 2),
-        (('G', 3), 'D', True, 3),
+        (notes.Note('C', 3), 'E', True, 2),
+        (notes.Note('C', 3), 'C', True, 3),
+        (notes.Note('C', 3), 'C', False, 2),
+        (notes.Note('G', 3), 'D', True, 3),
     ]
 )
-def test_nearest_above(note: tuple[str, int], other: str, allow_equal: bool, octave: int) -> None:
+def test_nearest_above(note: notes.Note, other: str, allow_equal: bool, octave: int) -> None:
     expected = notes.Note(other, octave)
-    actual = notes.Note(*note).nearest_below(other, allow_equal=allow_equal)
+    actual = note.nearest_below(other, allow_equal=allow_equal)
     assert actual == expected
 
 

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -234,12 +234,12 @@ def test_chord_name_error() -> None:
 def test_chord_name_to_chord(name: str, expected: list) -> None:
     chord_name = notes.ChordName(name)
     expected = notes.Chord([notes.Note(*n) for n in expected])
-    actual = chord_name.get_chord()
+    actual = chord_name.get_close_chord()
     assert actual == expected
 
 
 def test_chord_name_to_chord_different_lower() -> None:
-    actual = notes.ChordName('C').get_chord(lower=notes.Note('E', 2))
+    actual = notes.ChordName('C').get_close_chord(lower=notes.Note('E', 2))
     expected = notes.Chord([
         notes.Note('C', 3),
         notes.Note('E', 3),


### PR DESCRIPTION
This adds a couple extensions:
- inversions are correctly reflected, e.g. `C/E` will have `E` as the root note
- `ChordName.get_chord()` is now more precisely called `get_close_chord()`
- ~a new `get_all_chords` method is added that returns all voicings of a given chord that can fit between and upper and lower note~ (splitting this out into a separate PR)