### PR TITLE
Add upper extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,16 @@ To generate a compatible environment with required dependencies, you can use con
 conda env create --file environment.yml
 conda activate music
 ```
+
+## TODO
+
+- [ ] Add upper extensions
+- [ ] Add playability heuristics
+- [ ] Better ranking
+- [ ] Show voicings on staff
+- [ ] Better GUI
+  - [ ] Sort on different metrics
+  - [ ] Better input for specifying tuning
+- [ ] Automated testing
+- [ ] Deploy on AWS
+- [ ] Request logging?

--- a/notes.py
+++ b/notes.py
@@ -16,15 +16,12 @@ class Note:
         'A': 9,
         'B': 11
     }
-
     MODIFIER_MAPPER: dict[str, int] = {
         'bb': -2,
         'b': -1,
         '': 0,
         '#': 1,
         '##': 2,
-        's': 1,
-        'ss': 2,
     }
 
     ALL_NOTES_NAMES: list[str] = [
@@ -154,15 +151,34 @@ class ChordName:
 
     QUALITY_SEMITONE_MAPPER = {
         '': [0, 4, 7],
+        'maj': [0, 4, 7],
         'm': [0, 3, 7],
+        'min': [0, 3, 7],
         'dim': [0, 3, 6],
         'aug': [0, 4, 8],
+        'sus2': [0, 2, 7],
+        'sus4': [0, 5, 7],
         'maj7': [0, 4, 7, 11],
+        'M7': [0, 4, 7, 11],
         '7': [0, 4, 7, 10],
+        'min7': [0, 3, 7, 10],
         'm7': [0, 3, 7, 10],
         'm7b5': [0, 3, 6, 10],
         'dim7': [0, 3, 6, 9],
         'aug7': [0, 4, 8, 10],
+        '6': [0, 4, 7, 9],
+    }
+    DEGREE_SEMITONE_MAPPER = {
+        1: 0, 2: 2, 3: 4, 4: 5, 5: 7, 6: 9, 7: 11
+    }
+    EXTENSION_SEMITONE_MAPPER = {
+        str((deg - 1) + 8): semitones + 12
+        for deg, semitones in DEGREE_SEMITONE_MAPPER.items()
+    }
+    EXTENSION_SEMITONE_MAPPER = {
+        mod + ext: semis + mod_semis
+        for ext, semis in EXTENSION_SEMITONE_MAPPER.items()
+        for  mod, mod_semis in Note.MODIFIER_MAPPER.items()
     }
     FLAT_KEYS = ['C', 'F', 'Bb', 'Eb', 'Ab', 'Db', 'Gb', 'Cb', 'Fb', 'Bbb', 'Ebb', 'Abb', 'Dbb']
     SHARP_KEYS = ['G', 'D', 'A', 'E', 'B', 'F#', 'C#', 'G#', 'D#', 'A#', 'E#', 'B#', 'F##']
@@ -172,22 +188,8 @@ class ChordName:
     }
 
     def __init__(self, chord_name: str):
-        chord_notes = []
-        for note_name in Note.ALL_NOTES_NAMES:
-            if chord_name.startswith(note_name):
-                chord_notes.append(note_name)
-        try:
-            chord_note = max(chord_notes, key=len)
-        except ValueError:
-            raise ValueError(f'Invalid chord name; must start with one of {Note.ALL_NOTES_NAMES}')
-        if '/' in chord_name:
-            chord_name, root = chord_name.split('/')
-        else:
-            root = chord_note
-        quality = chord_name.replace(chord_note, '')
-        self.chord_note = chord_note
-        self.root = root
-        self.quality = quality
+        self.chord_note, self.quality, self.extensions, self.root = self.parse_name(chord_name)
+        self.chord_name = chord_name
         self.note_names = [
             Note(self.chord_note, octave=0).add_semitones(s, bias=self.KEY_BIAS[self.chord_note]).name
             for s in self.QUALITY_SEMITONE_MAPPER[self.quality]
@@ -200,6 +202,39 @@ class ChordName:
             self.note_names = _rotate_list(self.note_names, root_index)
         else:
             self.note_names.insert(0, self.root)
+        for ext in self.extensions:
+            bias = ext[0] if len(ext) > 1 else 'b'
+            self.note_names.append(
+                Note(self.chord_note, octave=1).add_semitones(
+                    self.EXTENSION_SEMITONE_MAPPER[ext], bias=bias
+                ).name
+            )
+
+    def parse_name(self, name: str) -> tuple[str, str, list[str], str]:
+        try:
+            chord_note = best_match(name, Note.ALL_NOTES_NAMES)
+        except ValueError:
+            raise ValueError(f'Invalid chord name; must start with one of {Note.ALL_NOTES_NAMES}')
+        if '/' in name:
+            remainder, root = name.split('/')
+        else:
+            remainder = name
+            root = chord_note
+        remainder = remainder.replace(chord_note, '')
+        try:
+            quality = best_match(remainder, list(self.QUALITY_SEMITONE_MAPPER.keys()))
+        except ValueError:
+            raise ValueError(f'Invalid chord name; quality must be one of {self.QUALITY_SEMITONE_MAPPER.keys()}')
+        remainder = remainder.replace(quality, '')
+        extensions = []
+        while remainder:
+            try:
+                extensions.append(best_match(remainder, list(self.EXTENSION_SEMITONE_MAPPER.keys())))
+            except ValueError:
+                raise ValueError(f'Invalid chord name; extensions must be one of {self.EXTENSION_SEMITONE_MAPPER.keys()}')
+            remainder = remainder.replace(extensions[-1], '')
+        assert not remainder
+        return chord_note, quality, extensions, root
 
     def get_chord(
             self, *, lower: 'Note' = Note('C', 0), raise_octave: dict[str, int] = None
@@ -333,3 +368,11 @@ def _rotate_list(l: list[Any], n: int) -> list[Any]:
     if n >= len(l):
         raise ValueError
     return l[n:] + l[:n]
+
+
+def best_match(s: str, choices: list[str]) -> str:
+    matches = []
+    for choice in choices:
+        if s.startswith(choice):
+            matches.append(choice)
+    return max(matches, key=len)

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -220,7 +220,7 @@ def test_chord_name(name: str, expected: dict) -> None:
     assert chord_name.root == expected['root']
     assert chord_name.chord_note == expected['chord_note']
     assert chord_name.quality == expected['quality']
-    assert chord_name.note_names == expected['notes']
+    assert chord_name.note_names + chord_name.extension_names == expected['notes']
     assert chord_name.extensions == expected.get('extensions', [])
 
 
@@ -281,6 +281,20 @@ def test_get_all_chords() -> None:
         notes.Chord([notes.Note(*note) for note in [('C', 0), ('E', 2), ('G', 1)]]),
         notes.Chord([notes.Note(*note) for note in [('C', 1), ('E', 1), ('G', 1)]]),
         notes.Chord([notes.Note(*note) for note in [('C', 1), ('E', 2), ('G', 1)]]),
+    ]
+    assert sorted(expected, key=str) == sorted(actual, key=str)
+
+def test_get_all_chords_extension() -> None:
+    actual = notes.ChordName('C9').get_all_chords(
+        lower=notes.Note('C', 0), upper=notes.Note('E', 2)
+    )
+    expected = [
+        notes.Chord([notes.Note(*note) for note in [('C', 0), ('E', 0), ('G', 0), ('D', 1)]]),
+        notes.Chord([notes.Note(*note) for note in [('C', 0), ('E', 0), ('G', 0), ('D', 2)]]),
+        notes.Chord([notes.Note(*note) for note in [('C', 0), ('E', 1), ('G', 0), ('D', 2)]]),
+        notes.Chord([notes.Note(*note) for note in [('C', 0), ('E', 0), ('G', 1), ('D', 2)]]),
+        notes.Chord([notes.Note(*note) for note in [('C', 0), ('E', 1), ('G', 1), ('D', 2)]]),
+        notes.Chord([notes.Note(*note) for note in [('C', 1), ('E', 1), ('G', 1), ('D', 2)]]),
     ]
     assert sorted(expected, key=str) == sorted(actual, key=str)
 

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -40,19 +40,6 @@ def test_note_from_string(name: str, expected: notes.Note) -> None:
     assert actual == expected
 
 
-def test_both_sharps_work() -> None:
-    assert (
-        notes.Note('F#', 3) ==
-        notes.Note('Fs', 3) ==
-        notes.Note('Gb', 3)
-    )
-    assert (
-        notes.Note('C##', 2) ==
-        notes.Note('Css', 2) ==
-        notes.Note('D', 2)
-    )
-
-
 @pytest.mark.parametrize(
     'semitones,expected',
     [
@@ -198,15 +185,20 @@ def test_parse_tuning(string: str) -> None:
         # TODO: this gets some enharmonics wrong, but it shouldn't double count the root note at least
         # all qualities
         ('C', {'chord_note': 'C', 'root': 'C', 'quality': '', 'notes': ['C', 'E', 'G']}),
+        ('Cmaj', {'chord_note': 'C', 'root': 'C', 'quality': 'maj', 'notes': ['C', 'E', 'G']}),
         ('Cm', {'chord_note': 'C', 'root': 'C', 'quality': 'm', 'notes': ['C', 'Eb', 'G']}),
+        ('Cmin', {'chord_note': 'C', 'root': 'C', 'quality': 'min', 'notes': ['C', 'Eb', 'G']}),
         ('Cdim', {'chord_note': 'C', 'root': 'C', 'quality': 'dim', 'notes': ['C', 'Eb', 'Gb']}),
         ('Caug', {'chord_note': 'C', 'root': 'C', 'quality': 'aug', 'notes': ['C', 'E', 'Ab']}),
+        ('Csus2', {'chord_note': 'C', 'root': 'C', 'quality': 'sus2', 'notes': ['C', 'D', 'G']}),
+        ('Csus4', {'chord_note': 'C', 'root': 'C', 'quality': 'sus4', 'notes': ['C', 'F', 'G']}),
         ('Cmaj7', {'chord_note': 'C', 'root': 'C', 'quality': 'maj7', 'notes': ['C', 'E', 'G', 'B']}),
         ('C7', {'chord_note': 'C', 'root': 'C', 'quality': '7', 'notes': ['C', 'E', 'G', 'Bb']}),
         ('Cm7', {'chord_note': 'C', 'root': 'C', 'quality': 'm7', 'notes': ['C', 'Eb', 'G', 'Bb']}),
         ('Cm7b5', {'chord_note': 'C', 'root': 'C', 'quality': 'm7b5', 'notes': ['C', 'Eb', 'Gb', 'Bb']}),
         ('Cdim7', {'chord_note': 'C', 'root': 'C', 'quality': 'dim7', 'notes': ['C', 'Eb', 'Gb', 'A']}),
         ('Caug7', {'chord_note': 'C', 'root': 'C', 'quality': 'aug7', 'notes': ['C', 'E', 'Ab', 'Bb']}),
+        ('C6', {'chord_note': 'C', 'root': 'C', 'quality': '6', 'notes': ['C', 'E', 'G', 'A']}),
         # other keys
         ('F#', {'chord_note': 'F#', 'root': 'F#', 'quality': '', 'notes': ['F#', 'A#', 'C#']}),
         ('F#m7b5', {'chord_note': 'F#', 'root': 'F#', 'quality': 'm7b5', 'notes': ['F#', 'A', 'C', 'E']}),
@@ -217,6 +209,10 @@ def test_parse_tuning(string: str) -> None:
         ('C/C', {'chord_note': 'C', 'root': 'C', 'quality': '', 'notes': ['C', 'E', 'G']}),
         ('Gm/Bb', {'chord_note': 'G', 'root': 'Bb', 'quality': 'm', 'notes': ['A#', 'D', 'G']}),
         ('Gm/A#', {'chord_note': 'G', 'root': 'A#', 'quality': 'm', 'notes': ['A#', 'D', 'G']}),
+        # Extensions
+        ('C9', {'chord_note': 'C', 'root': 'C', 'quality': '', 'extensions': ['9'], 'notes': ['C', 'E', 'G', 'D']}),
+        ('Cm#11', {'chord_note': 'C', 'root': 'C', 'quality': 'm', 'extensions': ['#11'], 'notes': ['C', 'Eb', 'G', 'F#']}),
+        ('D7b13/F#', {'chord_note': 'D', 'root': 'F#', 'quality': '7', 'extensions': ['b13'], 'notes': ['F#', 'A', 'C', 'D', 'Bb']}),
     ]
 )
 def test_chord_name(name: str, expected: dict) -> None:
@@ -225,6 +221,7 @@ def test_chord_name(name: str, expected: dict) -> None:
     assert chord_name.chord_note == expected['chord_note']
     assert chord_name.quality == expected['quality']
     assert chord_name.note_names == expected['notes']
+    assert chord_name.extensions == expected.get('extensions', [])
 
 
 def test_chord_name_error() -> None:
@@ -334,3 +331,11 @@ def test_rotate_list(l: list[int], n: int, expected: list[int]) -> None:
     else:
         actual = notes._rotate_list(l, n)
         assert actual == expected
+
+
+def test_best_match() -> None:
+    s = 'hello there'
+    choices = ['h', 'hi', 'hello', 'hello bob']
+    assert notes.best_match(s, choices) == 'hello'
+    with pytest.raises(ValueError):
+        notes.best_match(s, [choices[1], choices[3]])


### PR DESCRIPTION
This allows upper extensions to be added (e.g., `b9`, `#11`, etc.). Note they are constrained to be above the main chord. Also, as an aside, some more qualities are added, including aliases (e.g., `min` == `m`), 6 chords, sus chords, etc.

TODO:
- [ ] there is currently still an issue in `ChordName.parse_name()` where for `Cb9`, it would be ambiguous whether it's referring to Cb add 9 or C add flat9 🤔 