### PR TITLE
Better playability logic and repeated note bugfix

### DIFF
--- a/notes.py
+++ b/notes.py
@@ -1,7 +1,7 @@
 #! /usr/bin/python
 from copy import deepcopy
 from functools import total_ordering
-from itertools import permutations, product, combinations
+from itertools import permutations, product, combinations_with_replacement
 import json
 from typing import Hashable, Optional, Any, Literal
 
@@ -282,7 +282,7 @@ class ChordName:
             note_sets = []
             available_strings = max_notes - len(self.note_names + self.extension_names)
             for repeat in range(available_strings + 1):
-                new_note_sets = [self.note_names + list(add) for add in combinations(self.note_names, r=repeat)]
+                new_note_sets = [self.note_names + list(add) for add in combinations_with_replacement(self.note_names, r=repeat)]
                 note_sets += new_note_sets
             for note_set in note_sets:
                 mod_self = deepcopy(self)
@@ -375,7 +375,7 @@ class GuitarPosition:
         if n_notes <= 4:
             return True
         # Can always play a 5th note with thumb on bottom string
-        if n_notes == 5 and self.positions_dict.get(self.guitar.string_names[0], 0) > 0:
+        if n_notes == 5 and self.positions_dict.get(self.guitar.string_names[0], 0) == self.lowest_fret:
             return True
         # Otherwise, cannot be on more than 4 frets (at least some notes must be barred)
         if n_frets > 4:

--- a/notes.py
+++ b/notes.py
@@ -334,8 +334,13 @@ class GuitarPosition:
         }
         self.open_strings = [string for string, position in self.positions_dict.items() if position == 0]
         self.muted_strings = [string for string in self.guitar.string_names if string not in self.positions_dict]
+        self.fretted_strings = [string for string, position in self.positions_dict.items() if position > 0]
         self.max_interior_gap = self._max_interior_gap()
         self.playable = self.is_playable()
+        self.barre = (
+            self.playable and len(self.fretted_strings) > 4 and
+            sum(fret == self.lowest_fret for fret in self.positions_dict.values()) > 1
+        )
         # If all fretted notes are >= fret 12, this is a redundant position
         # there is an identical shape 12 frets below that gives (nearly) the same voicing
         self.redundant = all(fret >= 12 for fret in self.positions_dict.values() if fret != 0)
@@ -364,19 +369,24 @@ class GuitarPosition:
         # Too wide
         if self.fret_span > 5:
             return False
-        n_notes = len(self.positions_dict)
+        n_notes = len([val for val in self.positions_dict.values() if val > 0])
         n_frets = len(set(self.positions_dict.values()))
         # Can always play 4 fretted notes
         if n_notes <= 4:
             return True
         # Can always play a 5th note with thumb on bottom string
-        if n_notes == 5 and self.guitar.string_names[0] in self.positions_dict:
+        if n_notes == 5 and self.positions_dict.get(self.guitar.string_names[0], 0) > 0:
             return True
         # Otherwise, cannot be on more than 4 frets (at least some notes must be barred)
-        if n_frets <= 4:
-            return True
-        else:
+        if n_frets > 4:
             return False
+        # Cannot have more than 3 fretted notes above barred
+        if sum(fret > self.lowest_fret for fret in self.positions_dict.values()) > 3:
+            return False
+        if sum(fret == self.lowest_fret for fret in self.positions_dict.values()) == 1:
+            return False
+        else:
+            return True
 
     def __eq__(self, other: 'GuitarPosition') -> bool:
         return self.positions_dict == other.positions_dict

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -451,3 +451,15 @@ def test_best_match() -> None:
     assert notes.best_match(s, choices) == 'hello'
     with pytest.raises(ValueError):
         notes.best_match(s, [choices[1], choices[3]])
+
+
+def test_is_playable() -> None:
+    assert notes.GuitarPosition({'E': 3, 'A': 5, 'D': 5, 'G': 4, 'B': 3, 'e': 3}).playable
+    assert notes.GuitarPosition({'D': 0, 'G': 2, 'B': 3, 'e': 2}).playable
+    assert not notes.GuitarPosition({'E': 3, 'A': 5, 'D': 5, 'G': 4, 'B': 3, 'e': 1}).playable
+
+
+def test_is_barre() -> None:
+    assert notes.GuitarPosition({'E': 3, 'A': 5, 'D': 5, 'G': 4, 'B': 3, 'e': 3}).barre
+    assert not notes.GuitarPosition({'D': 0, 'G': 2, 'B': 3, 'e': 2}).barre
+    assert not notes.GuitarPosition({'E': 3, 'A': 5, 'D': 5, 'G': 4, 'B': 3, 'e': 1}).barre

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -457,6 +457,9 @@ def test_is_playable() -> None:
     assert notes.GuitarPosition({'E': 3, 'A': 5, 'D': 5, 'G': 4, 'B': 3, 'e': 3}).playable
     assert notes.GuitarPosition({'D': 0, 'G': 2, 'B': 3, 'e': 2}).playable
     assert not notes.GuitarPosition({'E': 3, 'A': 5, 'D': 5, 'G': 4, 'B': 3, 'e': 1}).playable
+    assert notes.GuitarPosition({'E': 3, 'A': 2, 'D': 0, 'G': 0, 'B': 0, 'e': 3}).playable
+    assert notes.GuitarPosition({'E': 3, 'A': 2, 'D': 0, 'G': 0, 'B': 3, 'e': 3}).playable
+    assert not notes.GuitarPosition({'E': 3, 'A': 2, 'D': 0, 'G': 4, 'B': 3, 'e': 3}).playable
 
 
 def test_is_barre() -> None:


### PR DESCRIPTION
This adds a couple things:

1. When repeated notes were added in #16, only combinations of repeated notes (with no replacements were allowed); in principle, we should let chords have >2 repeats of chord tones (this was discovered when the "standard" G cowboy chord never showed up)
2. `is_playable` is updated to add a few more constraints (barre chords can't have fretted noted below the barred fret, e.g., or more than 3 fingers above); also. `is_barre` attr is added (will use this in a follow up to improve the graphical printouts)