### PR TITLE
Print barre chords

### DIFF
--- a/notes.py
+++ b/notes.py
@@ -337,8 +337,13 @@ class GuitarPosition:
         self.fretted_strings = [string for string, position in self.positions_dict.items() if position > 0]
         self.max_interior_gap = self._max_interior_gap()
         self.playable = self.is_playable()
+        # Barre chord needs
         self.barre = (
-            self.playable and len(self.fretted_strings) > 4 and
+            self.playable and
+            # more than 4 fretted strings
+            len(self.fretted_strings) > 4 and
+            # no open strings
+            len(self.open_strings) == 0 and
             sum(fret == self.lowest_fret for fret in self.positions_dict.values()) > 1
         )
         # If all fretted notes are >= fret 12, this is a redundant position
@@ -408,9 +413,12 @@ class GuitarPosition:
         rows = []
         widest_name = max(len(str(string)) for string in self.guitar.string_names)
         if self.barre:
-            barre_strings = [i for i, val in enumerate(self.positions_dict.values()) if val == self.lowest_fret]
-            highest_barre_index = len(self.guitar.string_names) - min(barre_strings) - 1
-            lowest_barre_index = len(self.guitar.string_names) - max(barre_strings) - 1
+            barre_strings = [
+                i for i, string in enumerate(reversed(self.guitar.string_names))
+                if self.positions_dict.get(string, -1) == self.lowest_fret
+            ]
+            lowest_barre_index = min(barre_strings)
+            highest_barre_index = max(barre_strings)
         for i, string in enumerate(reversed(self.guitar.string_names)):
             left_padding = ' ' * (widest_name - len(str(string)))
             frets = ['---'] * self.fret_span

--- a/notes.py
+++ b/notes.py
@@ -407,7 +407,11 @@ class GuitarPosition:
         """
         rows = []
         widest_name = max(len(str(string)) for string in self.guitar.string_names)
-        for string in reversed(self.guitar.string_names):
+        if self.barre:
+            barre_strings = [i for i, val in enumerate(self.positions_dict.values()) if val == self.lowest_fret]
+            highest_barre_index = len(self.guitar.string_names) - min(barre_strings) - 1
+            lowest_barre_index = len(self.guitar.string_names) - max(barre_strings) - 1
+        for i, string in enumerate(reversed(self.guitar.string_names)):
             left_padding = ' ' * (widest_name - len(str(string)))
             frets = ['---'] * self.fret_span
             fret = self.positions_dict.get(string, -1)
@@ -416,6 +420,9 @@ class GuitarPosition:
                 ring_status = ' '
             else:
                 ring_status = 'o' if fret == 0 else 'x'
+            if self.barre:
+                if lowest_barre_index < i < highest_barre_index:
+                    frets[0] = '-|-'
             row = f'{left_padding}{string} {ring_status}|{"|".join(frets)}|'
             rows.append(row)
         if self.lowest_fret > 1:

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -201,6 +201,22 @@ def test_print_more_complex() -> None:
     assert actual == expected
 
 
+def test_print_barre() -> None:
+    position = notes.GuitarPosition({'E': 3, 'A': 5, 'D': 5, 'G': 4, 'B': 3, 'e': 3})
+    assert position.barre
+    expected = [
+        "e  |-@-|---|---|",
+        "B  |-|-|---|---|",
+        "G  |-|-|-@-|---|",
+        "D  |-|-|---|-@-|",
+        "A  |-|-|---|-@-|",
+        "E  |-@-|---|---|",
+        "  2fr",
+    ]
+    actual = position.printable()
+    assert actual == expected
+
+
 @pytest.mark.parametrize(
     'string',
     [

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -202,6 +202,7 @@ def test_print_more_complex() -> None:
 
 
 def test_print_barre() -> None:
+    # G
     position = notes.GuitarPosition({'E': 3, 'A': 5, 'D': 5, 'G': 4, 'B': 3, 'e': 3})
     assert position.barre
     expected = [
@@ -212,6 +213,20 @@ def test_print_barre() -> None:
         "A  |-|-|---|-@-|",
         "E  |-@-|---|---|",
         "  2fr",
+    ]
+    actual = position.printable()
+    assert actual == expected
+    # G7
+    position = notes.GuitarPosition({'A': 10, 'D': 12, 'G': 10, 'B': 12, 'e': 10})
+    assert position.barre
+    expected = [
+        "e  |-@-|---|---|",
+        "B  |-|-|---|-@-|",
+        "G  |-|-|---|---|",
+        "D  |-|-|---|-@-|",
+        "A  |-@-|---|---|",
+        "E x|---|---|---|",
+        "  9fr",
     ]
     actual = position.printable()
     assert actual == expected


### PR DESCRIPTION
This adds support to print barre chords explicitly with the barred fret, e.g., G7:

```
e  |-@-|---|---|
B  |-|-|---|---|
G  |-|-|-@-|---|
D  |-|-|---|---|
A  |-|-|---|-@-|
E  |-@-|---|---|
  2fr

```

