### PR TITLE
Don't accumulate unplayable

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,7 +96,7 @@ def display_name(chord_name: str, top_n: str, tuning: str, allow_repeats: str, a
     for chord in chords:
         positions_playable += chord.guitar_positions(guitar=guitar, include_unplayable=False, allow_thumb=allow_thumb_)
         positions_all += chord.num_total_guitar_positions
-    if allow_repeats == 'true':
+    if allow_repeats_:
         positions_playable = notes.filter_subset_guitar_positions(positions_playable)
     positions = notes.sort_guitar_positions(positions_playable)[:top_n_]
     positions_printable = ['<br>'.join(p.printable()) for p in positions]

--- a/app.py
+++ b/app.py
@@ -61,18 +61,15 @@ def display_notes(notes_string: str, top_n: str, tuning: str, allow_thumb: str) 
         notes.Guitar(tuning=notes.Guitar.parse_tuning(tuning_.split(';')[1]))
     )
     t1 = time.time()
-    positions_all = chord.guitar_positions(guitar=guitar)
-    if allow_thumb_:
-        positions_playable = list(filter(lambda x: (x.playable and not x.redundant), positions_all))
-    else:
-        positions_playable = list(filter(lambda x: (x.playable and not x.redundant and not x.use_thumb), positions_all))
+    positions_playable = chord.guitar_positions(guitar=guitar, include_unplayable=False, allow_thumb=allow_thumb_)
+    positions_all = chord.num_total_guitar_positions
     positions = notes.sort_guitar_positions(positions_playable)[:top_n_]
     positions_printable = ['<br>'.join(p.printable()) for p in positions]
     elapsed_time = f'{(time.time() - t1):.2f}'
     return render_template(
         'display.html',
         chord=chord, tuning=tuning_, positions=positions_printable,
-        total_n=len(positions_all), playable_n=len(positions_playable), elapsed_time=elapsed_time
+        total_n=positions_all, playable_n=len(positions_playable), elapsed_time=elapsed_time
     )
 
 
@@ -94,14 +91,12 @@ def display_name(chord_name: str, top_n: str, tuning: str, allow_repeats: str, a
         lower=guitar.lowest, upper=guitar.highest,
         allow_repeats=allow_repeats_, max_notes=len(guitar.tuning)
     )
-    positions_all = []
+    positions_playable = []
+    positions_all = 0
     for chord in chords:
-        positions_all += chord.guitar_positions(guitar=guitar)
-    if allow_thumb_:
-        positions_playable = list(filter(lambda x: (x.playable and not x.redundant), positions_all))
-    else:
-        positions_playable = list(filter(lambda x: (x.playable and not x.redundant and not x.use_thumb), positions_all))
-    if allow_repeats_:
+        positions_playable += chord.guitar_positions(guitar=guitar, include_unplayable=False, allow_thumb=allow_thumb_)
+        positions_all += chord.num_total_guitar_positions
+    if allow_repeats == 'true':
         positions_playable = notes.filter_subset_guitar_positions(positions_playable)
     positions = notes.sort_guitar_positions(positions_playable)[:top_n_]
     positions_printable = ['<br>'.join(p.printable()) for p in positions]
@@ -109,7 +104,7 @@ def display_name(chord_name: str, top_n: str, tuning: str, allow_repeats: str, a
     return render_template(
         'display.html',
         chord=chord_name_, tuning=tuning_, positions=positions_printable,
-        total_n=len(positions_all), playable_n=len(positions_playable), elapsed_time=elapsed_time
+        total_n=positions_all, playable_n=len(positions_playable), elapsed_time=elapsed_time
     )
 
 

--- a/demo.py
+++ b/demo.py
@@ -41,26 +41,28 @@ if __name__ == "__main__":
         note_list = [notes.Note.from_string(note) for note in args.notes.split(',')]
         chord = notes.Chord(note_list)
         print(f'You input the chord: {chord}')
-        positions_all = chord.guitar_positions(guitar=guitar)
+        positions_playable = chord.guitar_positions(guitar=guitar, include_unplayable=False)
+        positions_all = chord.num_total_guitar_positions
     elif args.name:
         print(f'You input the chord: {args.name}')
         chords = notes.ChordName(args.name).get_all_chords(
             lower=guitar.lowest, upper=guitar.highest,
             allow_repeats=args.allow_repeats, max_notes=len(guitar.tuning)
         )
-        positions_all = []
+        positions_playable = []
+        positions_all = 0
         for chord in chords:
-            positions_all += chord.guitar_positions(guitar=guitar)
+            positions_playable += chord.guitar_positions(guitar=guitar, include_unplayable=False)
+            positions_all += chord.num_total_guitar_positions
     else:
         raise ValueError('Either `notes` or `name` is required')
-    positions_playable = list(filter(lambda x: (x.playable and not x.redundant), positions_all))
     if args.allow_repeats:
         positions_playable = notes.filter_subset_guitar_positions(positions_playable)
     positions = notes.sort_guitar_positions(positions_playable)[:args.top_n]
     t2 = time.time()
     tuning_display = guitar.tuning_name if guitar.tuning_name == 'standard' else f'{guitar.tuning_name} ({guitar}):'
     print(
-        f'There are {len(positions_playable)} playable guitar positions (out of {len(positions_all)} possible) '
+        f'There are {len(positions_playable)} playable guitar positions (out of {positions_all} possible) '
         f'for a guitar tuned to {tuning_display}.\n'
         f'(Computed in {(t2 - t1):.2f} seconds)'
     )

--- a/notes.py
+++ b/notes.py
@@ -118,7 +118,7 @@ class Chord:
         self.num_total_guitar_positions = None
         self.num_playable_guitar_positions = None
 
-    def guitar_positions(self, guitar: 'Guitar' = None, include_unplayable: bool=False) -> list['GuitarPosition']:
+    def guitar_positions(self, guitar: 'Guitar' = None, include_unplayable: bool = False, allow_thumb: bool = True) -> list['GuitarPosition']:
         guitar = guitar or Guitar()
         # This is a dict of dicts, {note: {string: fret for string in guitar} for note in chord}
         # of all the positions each note can be played on each string
@@ -142,7 +142,8 @@ class Chord:
             guitar_position = GuitarPosition(positions_dict, guitar=guitar)
             assert guitar_position.valid  # This should be true from above
             if (guitar_position.playable and not guitar_position.redundant) or include_unplayable:
-                playable_positions.append(guitar_position)
+                if allow_thumb or (not allow_thumb and not guitar_position.use_thumb):
+                    playable_positions.append(guitar_position)
         self.num_playable_guitar_positions = len(playable_positions)
         return sorted(playable_positions, key=lambda x: x.fret_span)
 

--- a/notes.py
+++ b/notes.py
@@ -115,8 +115,10 @@ class Note:
 class Chord:
     def __init__(self, notes: list[Note]):
         self.notes = sorted(notes)
+        self.num_total_guitar_positions = None
+        self.num_playable_guitar_positions = None
 
-    def guitar_positions(self, guitar: 'Guitar' = None) -> list['GuitarPosition']:
+    def guitar_positions(self, guitar: 'Guitar' = None, include_unplayable: bool=False) -> list['GuitarPosition']:
         guitar = guitar or Guitar()
         # This is a dict of dicts, {note: {string: fret for string in guitar} for note in chord}
         # of all the positions each note can be played on each string
@@ -130,7 +132,8 @@ class Chord:
             for note in self.notes
         ]
         valid_combinations = [comb for comb in product(*valid_strings) if len(set(comb)) == len(self.notes)]
-        valid_positions = []
+        self.num_total_guitar_positions = len(valid_combinations)
+        playable_positions = []
         for comb in valid_combinations:
             positions_dict = {
                 string: all_fret_positions[str(note)][string]
@@ -138,8 +141,10 @@ class Chord:
             }
             guitar_position = GuitarPosition(positions_dict, guitar=guitar)
             assert guitar_position.valid  # This should be true from above
-            valid_positions.append(guitar_position)
-        return sorted(valid_positions, key=lambda x: x.fret_span)
+            if (guitar_position.playable and not guitar_position.redundant) or include_unplayable:
+                playable_positions.append(guitar_position)
+        self.num_playable_guitar_positions = len(playable_positions)
+        return sorted(playable_positions, key=lambda x: x.fret_span)
 
     @staticmethod
     def from_string(string: str) -> 'Chord':

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -110,7 +110,7 @@ def test_different_guitar_tunings(strings: list[tuple[str, int]], capo: int) -> 
     )
     chord = notes.Chord([notes.Note(*string).add_semitones(capo) for string in strings])
     expected = {i: 0 for i in range(len(strings))}
-    actual = chord.guitar_positions(guitar=guitar)[0].positions_dict
+    actual = chord.guitar_positions(guitar=guitar, include_unplayable=True)[0].positions_dict
     assert actual == expected
 
 


### PR DESCRIPTION
The calculator is still running slow on my raspberry pi (over a minute for chords like a G7); I had the thought it might be memory bound in some way, so this reduces the memory footprint by not accumulating chords in the list that will ultimately get filtered out. However, it didn't seem to help. Still probably not a bad thing though.