### PR TITLE
Display improvements

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -21,9 +21,6 @@ if __name__ == "__main__":
         '--allow_repeats', '-r', action='store_true', help='Allow chord tones to appear more than once'
     )
     parser.add_argument(
-        '--allow_redundant', '-R', action='store_true', help='Allow redundant positions (fully above fret 12)'
-    )
-    parser.add_argument(
         '--graphical', '-g', action='store_true', help='Show ASCII art for guitar positions'
     )
     parser.add_argument(
@@ -56,9 +53,7 @@ if __name__ == "__main__":
             positions_all += chord.guitar_positions(guitar=guitar)
     else:
         raise ValueError('Either `notes` or `name` is required')
-    positions_playable = list(filter(lambda x: x.playable, positions_all))
-    if not args.allow_redundant:
-        positions_playable = list(filter(lambda x: not x.redundant, positions_playable))
+    positions_playable = list(filter(lambda x: (x.playable and not x.redundant), positions_all))
     if args.allow_repeats:
         positions_playable = notes.filter_subset_guitar_positions(positions_playable)
     positions = notes.sort_guitar_positions(positions_playable)[:args.top_n]

--- a/notes.py
+++ b/notes.py
@@ -353,8 +353,8 @@ class GuitarPosition:
         ]
         # Can play a 5th note with thumb on bottom string
         self.use_thumb = (
-                (len(self.fretted_strings) == 5) and
-                (self.positions_dict.get(self.guitar.string_names[0], -1) == self.lowest_fret)
+            (len(self.fretted_strings) == 5) and
+            (self.positions_dict.get(self.guitar.string_names[0], -1) == self.lowest_fret)
         )
         self.max_interior_gap = self._max_interior_gap()
         self.playable = self.is_playable()

--- a/notes.py
+++ b/notes.py
@@ -452,9 +452,9 @@ class GuitarPosition:
                     frets[0] = '-|-'
             row = f'{left_padding}{string} {ring_status}|{"|".join(frets)}|'
             rows.append(row)
-        if self.lowest_fret > 1:
+        if self.lowest_fret > 0:
             left_padding = ' ' * widest_name
-            rows.append(f'{left_padding} {self.lowest_fret - 1}fr')
+            rows.append(f'{left_padding}   {self.lowest_fret}fr')
         return rows
 
 

--- a/notes.py
+++ b/notes.py
@@ -382,16 +382,11 @@ class GuitarPosition:
         self.redundant = all(fret >= 12 for fret in self.positions_dict.values() if fret != 0)
 
     def _max_interior_gap(self) -> int:
-        if len(self.positions_dict) == 0:
+        if len(self.fretted_strings) == 0:
             return 0
-        lowest_fretted_string = list(self.positions_dict.keys())[0]
-        highest_fretted_string = list(self.positions_dict.keys())[-1]
         gap = 0
         max_gap = 0
-        for i in range(
-                self.guitar.string_names.index(lowest_fretted_string),
-                self.guitar.string_names.index(highest_fretted_string)
-        ):
+        for i in range(self.fretted_strings[0], self.fretted_strings[-1]):
             if self.positions_dict.get(self.guitar.string_names[i], 0) == 0:
                 gap += 1
             else:

--- a/notes.py
+++ b/notes.py
@@ -351,6 +351,11 @@ class GuitarPosition:
             i for i, string in enumerate(self.guitar.string_names)
             if self.positions_dict.get(string, -1) == self.lowest_fret
         ]
+        # Can play a 5th note with thumb on bottom string
+        self.use_thumb = (
+                (len(self.fretted_strings) == 5) and
+                (self.positions_dict.get(self.guitar.string_names[0], -1) == self.lowest_fret)
+        )
         self.max_interior_gap = self._max_interior_gap()
         self.playable = self.is_playable()
         # Barre chord needs
@@ -400,13 +405,12 @@ class GuitarPosition:
         # Too wide
         if self.fret_span > 5:
             return False
-        n_notes = len([val for val in self.positions_dict.values() if val > 0])
+        n_notes = len(self.fretted_strings)
         n_frets = len(set(self.positions_dict.values()))
         # Can always play 4 fretted notes
         if n_notes <= 4:
             return True
-        # Can always play a 5th note with thumb on bottom string
-        if n_notes == 5 and self.positions_dict.get(self.guitar.string_names[0], 0) == self.lowest_fret:
+        if self.use_thumb:
             return True
         # Otherwise, cannot be on more than 4 frets (at least some notes must be barred)
         if n_frets > 4:
@@ -439,11 +443,12 @@ class GuitarPosition:
         rows = []
         widest_name = max(len(str(string)) for string in self.guitar.string_names)
         for i, string in reversed(list(enumerate(self.guitar.string_names))):
+            fret_marker = '-T-' if string == self.guitar.string_names[0] and self.use_thumb else '-@-'
             left_padding = ' ' * (widest_name - len(str(string)))
             frets = ['---'] * self.fret_span
             fret = self.positions_dict.get(string, -1)
             if fret > 0:
-                frets[fret - self.lowest_fret] = '-@-'
+                frets[fret - self.lowest_fret] = fret_marker
                 ring_status = ' '
             else:
                 ring_status = 'o' if fret == 0 else 'x'

--- a/templates/input.html
+++ b/templates/input.html
@@ -37,6 +37,9 @@
                value="true" checked></input>
         <label for="allow_repeats"> Allow repeated chord tones</label><br>
         <br>
+        <input type="checkbox" id="allow_thumb" name="allow_thumb"
+               value="true" checked></input>
+        <label for="allow_thumb"> Allow positions requiring thumb</label><br>
         <br>
         <button type="submit">Submit</button>
     </form>

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -232,6 +232,32 @@ def test_print_barre() -> None:
     assert actual == expected
 
 
+def test_no_open_strings_along_barre() -> None:
+    position = notes.GuitarPosition({"E": 3, "D": 5, "G": 7, "B": 3, "e": 7})
+    assert not position.barre
+    expected = [
+        "e  |---|---|---|---|-@-|",
+        "B  |-@-|---|---|---|---|",
+        "G  |---|---|---|---|-@-|",
+        "D  |---|---|-@-|---|---|",
+        "A x|---|---|---|---|---|",
+        "E  |-@-|---|---|---|---|",
+        "  2fr",
+    ]
+    assert position.printable() == expected
+    position = notes.GuitarPosition({"E": 3, "A": 0, "D": 5, "G": 7, "B": 3, "e": 7})
+    assert not position.barre
+    expected = [
+        "e  |---|---|---|---|-@-|",
+        "B  |-@-|---|---|---|---|",
+        "G  |---|---|---|---|-@-|",
+        "D  |---|---|-@-|---|---|",
+        "A o|---|---|---|---|---|",
+        "E  |-@-|---|---|---|---|",
+        "  2fr",
+    ]
+    assert position.printable() == expected
+
 @pytest.mark.parametrize(
     'string',
     [

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -241,7 +241,7 @@ def test_no_open_strings_along_barre() -> None:
         "G  |---|---|---|---|-@-|",
         "D  |---|---|-@-|---|---|",
         "A x|---|---|---|---|---|",
-        "E  |-@-|---|---|---|---|",
+        "E  |-T-|---|---|---|---|",
         "    3fr",
     ]
     assert position.printable() == expected
@@ -253,7 +253,7 @@ def test_no_open_strings_along_barre() -> None:
         "G  |---|---|---|---|-@-|",
         "D  |---|---|-@-|---|---|",
         "A o|---|---|---|---|---|",
-        "E  |-@-|---|---|---|---|",
+        "E  |-T-|---|---|---|---|",
         "    3fr",
     ]
     assert position.printable() == expected

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -175,7 +175,7 @@ def test_print() -> None:
         "D  |-@-|",
         "A  |-@-|",
         "E x|---|",
-        "  1fr",
+        "    2fr",
     ]
     actual = position.printable()
     assert actual == expected
@@ -195,7 +195,7 @@ def test_print_more_complex() -> None:
         " d  |-@-|---|---|",
         " A  |-@-|---|---|",
         " D x|---|---|---|",
-        "   1fr",
+        "     2fr",
     ]
     actual = position.printable()
     assert actual == expected
@@ -212,7 +212,7 @@ def test_print_barre() -> None:
         "D  |-|-|---|-@-|",
         "A  |-|-|---|-@-|",
         "E  |-@-|---|---|",
-        "  2fr",
+        "    3fr",
     ]
     actual = position.printable()
     assert actual == expected
@@ -226,7 +226,7 @@ def test_print_barre() -> None:
         "D  |-|-|---|-@-|",
         "A  |-@-|---|---|",
         "E x|---|---|---|",
-        "  9fr",
+        "    10fr",
     ]
     actual = position.printable()
     assert actual == expected
@@ -242,7 +242,7 @@ def test_no_open_strings_along_barre() -> None:
         "D  |---|---|-@-|---|---|",
         "A x|---|---|---|---|---|",
         "E  |-@-|---|---|---|---|",
-        "  2fr",
+        "    3fr",
     ]
     assert position.printable() == expected
     position = notes.GuitarPosition({"E": 3, "A": 0, "D": 5, "G": 7, "B": 3, "e": 7})
@@ -254,7 +254,7 @@ def test_no_open_strings_along_barre() -> None:
         "D  |---|---|-@-|---|---|",
         "A o|---|---|---|---|---|",
         "E  |-@-|---|---|---|---|",
-        "  2fr",
+        "    3fr",
     ]
     assert position.printable() == expected
 


### PR DESCRIPTION
A few small cleanups, including:

- preventing chords from being labeled as barre if they have an open/muted string along the barre position
- labeling thumb positions and including an option to filter
- fret position label is clearer

Example of new display (this chord previously would have been marked barred from E to B):

```
e  |---|---|---|---|-@-|
B  |-@-|---|---|---|---|
G  |---|---|---|---|-@-|
D  |---|---|-@-|---|---|
A o|---|---|---|---|---|
E  |-T-|---|---|---|---|
    3fr
```