### PR TITLE
Optimize chord set calc

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ def input():
         notes_string = request.form['notes']
         chord_name = request.form['chord_name']
         allow_repeats = request.form.get('allow_repeats') or 'false'
+        allow_identical = request.form.get('allow_identical') or 'false'
         allow_thumb = request.form.get('allow_thumb') or 'false'
         if notes_string:
             return redirect(url_for(
@@ -38,6 +39,7 @@ def input():
                     top_n='top_n=' + top_n,
                     tuning='tuning=' + tuning,
                     allow_repeats='allow_repeats=' + allow_repeats,
+                    allow_identical='allow_identical=' + allow_identical,
                     allow_thumb='allow_thumb=' + allow_thumb,
                 ))
             except ValueError:
@@ -73,14 +75,17 @@ def display_notes(notes_string: str, top_n: str, tuning: str, allow_thumb: str) 
     )
 
 
-@app.route("/chord_name/<chord_name>/<top_n>/<tuning>/<allow_repeats>/<allow_thumb>")
-def display_name(chord_name: str, top_n: str, tuning: str, allow_repeats: str, allow_thumb: str) -> str:
+@app.route("/chord_name/<chord_name>/<top_n>/<tuning>/<allow_repeats>/<allow_identical>/<allow_thumb>")
+def display_name(
+        chord_name: str, top_n: str, tuning: str, allow_repeats: str, allow_identical: str, allow_thumb: str
+) -> str:
     chord_name_ = escape(chord_name).replace('_', '/')
     top_n_ = int(escape(top_n).split('=')[1])
     if top_n_ < 0:
         top_n_ = None
     tuning_ = escape(tuning).split('=')[1]
     allow_repeats_: bool = escape(allow_repeats).split('=')[1] == 'true'
+    allow_identical_: bool = escape(allow_identical).split('=')[1] == 'true'
     allow_thumb_: bool = escape(allow_thumb).split('=')[1] == 'true'
     guitar = (
         notes.Guitar() if tuning_ == 'standard' else
@@ -88,8 +93,8 @@ def display_name(chord_name: str, top_n: str, tuning: str, allow_repeats: str, a
     )
     t1 = time.time()
     chords = notes.ChordName(chord_name_).get_all_chords(
-        lower=guitar.lowest, upper=guitar.highest,
-        allow_repeats=allow_repeats_, max_notes=len(guitar.tuning)
+        lower=guitar.lowest, upper=guitar.highest, max_notes=len(guitar.tuning),
+        allow_repeats=allow_repeats_, allow_identical=allow_identical_,
     )
     positions_playable = []
     positions_all = 0

--- a/demo.py
+++ b/demo.py
@@ -18,7 +18,10 @@ if __name__ == "__main__":
         '--top_n', '-n', type=int, default=None, help='How many positions to return'
     )
     parser.add_argument(
-        '--allow_repeats', '-r', action='store_true', help='Allow chord tones to appear more than once'
+        '--allow_repeats', '-r', action='store_true', help='Allow chord tones to appear more than once (different octaves)'
+    )
+    parser.add_argument(
+        '--allow_identical', '-i', action='store_true', help='Allow chord tones to appear more than once in the same octave'
     )
     parser.add_argument(
         '--graphical', '-g', action='store_true', help='Show ASCII art for guitar positions'
@@ -46,8 +49,8 @@ if __name__ == "__main__":
     elif args.name:
         print(f'You input the chord: {args.name}')
         chords = notes.ChordName(args.name).get_all_chords(
-            lower=guitar.lowest, upper=guitar.highest,
-            allow_repeats=args.allow_repeats, max_notes=len(guitar.tuning)
+            lower=guitar.lowest, upper=guitar.highest, max_notes=len(guitar.tuning),
+            allow_repeats=args.allow_repeats, allow_identical=args.allow_identical,
         )
         positions_playable = []
         positions_all = 0

--- a/notes.py
+++ b/notes.py
@@ -1,5 +1,4 @@
 #! /usr/bin/python
-from copy import deepcopy
 from functools import total_ordering
 from itertools import product, combinations_with_replacement, combinations, chain
 import json
@@ -272,7 +271,6 @@ class ChordName:
             semitones_to_add = raise_octave.get(note_ind, 0) * 12
             notes.append(upper_chord.nearest_above(note_name).add_semitones(semitones_to_add))
         return Chord(notes)
-
 
     def get_all_chords(
             self, *, lower: 'Note' = Note('C', 0), upper: 'Note',

--- a/notes.py
+++ b/notes.py
@@ -551,7 +551,7 @@ def note_set(note_list: list[Note]) -> set[Note]:
 
 
 def constrained_powerset(
-        note_list: list[Note], max_len: int = 0, required_notes: set[Note] = None
+        note_list: list[Note], max_len: int = 0, required_notes: set[Note] = None, allow_repeats: bool = False
 ) -> list[list[Note]]:
     """
     Given a list a notes, return the powerset (list of lists of notes) such that:
@@ -560,6 +560,7 @@ def constrained_powerset(
     """
     max_len = max_len or len(note_list)
     required_notes = required_notes or note_set(note_list)
-    powerset = chain.from_iterable(combinations(note_list, r) for r in range(max_len + 1))
+    func = combinations_with_replacement if allow_repeats else combinations
+    powerset = chain.from_iterable(func(note_list, r) for r in range(max_len + 1))
     subet = [s for s in powerset if note_set(s) >= required_notes]
     return subet

--- a/notes.py
+++ b/notes.py
@@ -333,31 +333,44 @@ class ChordName:
     ) -> list['Chord']:
         max_octaves = (upper - lower) // 12 + 1
         required_notes = set(Note(name, 0) for name in self.note_names[1:])
-        chord_list = []
         possible_notes = [
             lower.nearest_above(note).add_semitones(12 * octave)
             for octave in range(max_octaves)
             for note in self.note_names
+            if lower.nearest_above(note).add_semitones(12 * octave) <= upper
         ]
+        possible_extensions = [
+            lower.nearest_above(ext).add_semitones(12 * octave)
+            for octave in range(1, max_octaves)
+            for ext in self.extension_names
+            if lower.nearest_above(ext).add_semitones(12 * octave) <= upper
+        ]
+        extensions = constrained_powerset(
+            possible_extensions, max_len=len(self.extension_names), allow_repeats=False
+        )
+        chord_list = []
         for root_octave in range(max_octaves):
             root_note = lower.nearest_above(self.root).add_semitones(12 * root_octave)
-            if allow_identical:
-                note_list = list(filter(lambda x: root_note <= x <= upper, possible_notes))
-            elif allow_repeats:
-                note_list = list(filter(lambda x: root_note < x <= upper, possible_notes))
-            else:
-                note_list = list(filter(lambda x: (root_note < x <= upper) and not x.same_name(root_note), possible_notes))
-            available_notes = max_notes - 1  # root note
-            mid_notes_list = constrained_powerset(
-                note_list, required_notes=required_notes,
-                max_len=available_notes,
-                allow_repeats=allow_repeats,
-                allow_identical=allow_identical
-            )
-            chord_list += [
-                Chord([root_note, *mid_notes])
-                for mid_notes in mid_notes_list
-            ]
+            for ext in extensions:
+                upper_ = min(ext) if ext else upper
+                if allow_identical:
+                    note_list = list(filter(lambda x: root_note <= x <= upper_, possible_notes))
+                elif allow_repeats:
+                    note_list = list(filter(lambda x: root_note < x <= upper_, possible_notes))
+                else:
+                    note_list = list(filter(lambda x: (root_note < x <= upper_) and not x.same_name(root_note), possible_notes))
+                available_notes = max_notes - 1 - len(ext)  # root and extensions are already taken
+                mid_notes_list = constrained_powerset(
+                    note_list,
+                    required_notes=required_notes,
+                    max_len=available_notes,
+                    allow_repeats=allow_repeats,
+                    allow_identical=allow_identical
+                )
+                chord_list += [
+                    Chord([root_note, *mid_notes, *ext])
+                    for mid_notes in mid_notes_list
+                ]
         return chord_list
 
 

--- a/templates/input.html
+++ b/templates/input.html
@@ -37,6 +37,11 @@
                value="true" checked></input>
         <label for="allow_repeats"> Allow repeated chord tones</label><br>
         <br>
+        <input type="checkbox" id="allow_identical" name="allow_identical"
+               value="true"></input>
+        <label for="allow_repeats"> Allow identical (same octave) chord tones<br>
+            (Warning, this may increase compute time)</label><br>
+        <br>
         <input type="checkbox" id="allow_thumb" name="allow_thumb"
                value="true" checked></input>
         <label for="allow_thumb"> Allow positions requiring thumb</label><br>

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -540,3 +540,78 @@ def test_thumb_position_not_barre() -> None:
         "    3fr",
     ]
     assert position.printable() == expected
+
+
+def test_constrained_powerset_same_len() -> None:
+    note_list = [
+        notes.Note('C', 0),
+        notes.Note('E', 0),
+        notes.Note('G', 0),
+        notes.Note('C', 1),
+        notes.Note('E', 1),
+        notes.Note('G', 1),
+    ]
+    expected = [
+        [notes.Note.from_string(s) for s in ['C0', 'E0', 'G0']],
+        [notes.Note.from_string(s) for s in ['C0', 'E0', 'G1']],
+        [notes.Note.from_string(s) for s in ['C0', 'G0', 'E1']],
+        [notes.Note.from_string(s) for s in ['C0', 'E1', 'G1']],
+        [notes.Note.from_string(s) for s in ['E0', 'G0', 'C1']],
+        [notes.Note.from_string(s) for s in ['E0', 'C1', 'G1']],
+        [notes.Note.from_string(s) for s in ['G0', 'C1', 'E1']],
+        [notes.Note.from_string(s) for s in ['C1', 'E1', 'G1']],
+    ]
+    actual = sorted(
+        [sorted(s) for s in notes.constrained_powerset(note_list, max_len=3)],
+    )
+    assert len(actual) == len(expected)
+    assert set(''.join(str(x)) for x in actual) == set(''.join(str(x)) for x in expected)
+
+
+def test_constrained_powerset_different_len() -> None:
+    note_list = [
+        notes.Note('C', 0),
+        notes.Note('E', 0),
+        notes.Note('C', 1),
+        notes.Note('E', 1),
+    ]
+    expected = [
+        [notes.Note.from_string(s) for s in ['C0', 'E0']],
+        [notes.Note.from_string(s) for s in ['C0', 'E1']],
+        [notes.Note.from_string(s) for s in ['E0', 'C1']],
+        [notes.Note.from_string(s) for s in ['C1', 'E1']],
+        [notes.Note.from_string(s) for s in ['C0', 'E0', 'C1']],
+        [notes.Note.from_string(s) for s in ['C0', 'E0', 'E1']],
+        [notes.Note.from_string(s) for s in ['C0', 'C1', 'E1']],
+        [notes.Note.from_string(s) for s in ['E0', 'C1', 'E1']],
+    ]
+    actual = sorted(
+        [sorted(s) for s in notes.constrained_powerset(note_list, max_len=3)],
+    )
+    assert len(actual) == len(expected)
+    assert set(''.join(str(x)) for x in actual) == set(''.join(str(x)) for x in expected)
+
+
+def test_constrained_powerset_different_required_notes() -> None:
+    note_list = [
+        notes.Note('C', 0),
+        notes.Note('E', 0),
+        notes.Note('G', 0),
+        notes.Note('C', 1),
+    ]
+    expected = [
+        [notes.Note.from_string(s) for s in ['C0', 'E0']],
+        [notes.Note.from_string(s) for s in ['E0', 'C1']],
+        [notes.Note.from_string(s) for s in ['C0', 'E0', 'C1']],
+        [notes.Note.from_string(s) for s in ['C0', 'E0', 'G0']],
+        [notes.Note.from_string(s) for s in ['E0', 'G0', 'C1']],
+    ]
+    temp = notes.constrained_powerset(
+        note_list,
+        max_len=3,
+        required_notes=notes.note_set([notes.Note('C', 0), notes.Note('E', 0)])
+    )
+    actual = [sorted(s) for s in temp]
+    print(actual)
+    assert len(actual) == len(expected)
+    assert set(''.join(str(x)) for x in actual) == set(''.join(str(x)) for x in expected)

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -396,7 +396,7 @@ def test_get_all_chords() -> None:
 def test_get_all_chords_with_repeats() -> None:
     actual = notes.ChordName('C').get_all_chords(
         lower=notes.Note('C', 0), upper=notes.Note('E', 1),
-        allow_repeats=True, max_notes=4
+        allow_repeats=True, allow_identical=True, max_notes=4
     )
     expected = [
         notes.Chord([notes.Note(*note) for note in [('C', 0), ('E', 0), ('G', 0)]]),
@@ -670,7 +670,7 @@ def test_constrained_powerset_dont_allow_repeats() -> None:
 
 
 @pytest.mark.parametrize('max_notes', [3, 4, 5, 6])
-def test_get_all_chords_2(max_notes: int) -> None:
+def test_get_all_chords_again(max_notes: int) -> None:
     c = notes.ChordName('C')
     expected = [
         notes.Chord.from_string('C0,E0,G0'),
@@ -679,11 +679,11 @@ def test_get_all_chords_2(max_notes: int) -> None:
         notes.Chord.from_string('C0,E1,G1'),
         notes.Chord.from_string('C1,E1,G1'),
     ]
-    actual = c.get_all_chords_refactor(upper=notes.Note('G', 1), max_notes=max_notes, allow_repeats=False)
+    actual = c.get_all_chords(upper=notes.Note('G', 1), max_notes=max_notes, allow_repeats=False)
     assert set(actual) == set(expected)
 
 
-def test_get_all_chords_2_allow_repeats() -> None:
+def test_get_all_chords_allow_repeats() -> None:
     c = notes.ChordName('C')
     expected = [
         notes.Chord.from_string('C0,E0,G0'),
@@ -700,11 +700,11 @@ def test_get_all_chords_2_allow_repeats() -> None:
         notes.Chord.from_string('C0,E1,G0,G1'),
         notes.Chord.from_string('C0,E0,G0,G1'),
     ]
-    actual = c.get_all_chords_refactor(upper=notes.Note('G', 1), max_notes=4, allow_repeats=True)
+    actual = c.get_all_chords(upper=notes.Note('G', 1), max_notes=4, allow_repeats=True)
     assert set(actual) == set(expected)
 
 
-def test_get_all_chords_2_allow_identical() -> None:
+def test_get_all_chords_allow_identical() -> None:
     c = notes.ChordName('C')
     expected = [
         notes.Chord.from_string('C0,E0,G0'),
@@ -738,20 +738,20 @@ def test_get_all_chords_2_allow_identical() -> None:
         notes.Chord.from_string('C0,G0,E1,E1'),
         notes.Chord.from_string('C1,E1,G1,G1'),
     ]
-    actual = c.get_all_chords_refactor(
+    actual = c.get_all_chords(
         upper=notes.Note('G', 1), max_notes=4,
         allow_repeats=True, allow_identical=True
     )
     assert set(actual) == set(expected)
 
 
-def test_get_all_chords_2_allow_identical() -> None:
+def test_get_all_chords_extension() -> None:
     c = notes.ChordName('Cmaj79')
     expected = [
         notes.Chord.from_string('C0,E0,G0,B0,D1'),
         notes.Chord.from_string('C0,E0,G0,B0,C1,D1'),
     ]
-    actual = c.get_all_chords_refactor(
+    actual = c.get_all_chords(
         upper=notes.Note('C', 2), max_notes=6,
         allow_repeats=True, allow_identical=False
     )

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -743,3 +743,16 @@ def test_get_all_chords_2_allow_identical() -> None:
         allow_repeats=True, allow_identical=True
     )
     assert set(actual) == set(expected)
+
+
+def test_get_all_chords_2_allow_identical() -> None:
+    c = notes.ChordName('Cmaj79')
+    expected = [
+        notes.Chord.from_string('C0,E0,G0,B0,D1'),
+        notes.Chord.from_string('C0,E0,G0,B0,C1,D1'),
+    ]
+    actual = c.get_all_chords_refactor(
+        upper=notes.Note('C', 2), max_notes=6,
+        allow_repeats=True, allow_identical=False
+    )
+    assert set(actual) == set(expected)

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -607,8 +607,7 @@ def test_constrained_powerset_different_required_notes() -> None:
         [notes.Note.from_string(s) for s in ['E0', 'G0', 'C1']],
     ]
     temp = notes.constrained_powerset(
-        note_list,
-        max_len=3,
+        note_list, max_len=3,
         required_notes=notes.note_set([notes.Note('C', 0), notes.Note('E', 0)])
     )
     actual = [sorted(s) for s in temp]
@@ -617,7 +616,7 @@ def test_constrained_powerset_different_required_notes() -> None:
     assert set(''.join(str(x)) for x in actual) == set(''.join(str(x)) for x in expected)
 
 
-def test_constrained_powerset_allow_repeats() -> None:
+def test_constrained_powerset_allow_identical() -> None:
     note_list = [
         notes.Note('C', 0),
         notes.Note('E', 0),
@@ -636,12 +635,111 @@ def test_constrained_powerset_allow_repeats() -> None:
         [notes.Note.from_string(s) for s in ['E0', 'G0', 'C1']],
     ]
     temp = notes.constrained_powerset(
-        note_list,
-        max_len=3,
+        note_list, max_len=3,
         required_notes=notes.note_set([notes.Note('C', 0), notes.Note('E', 0)]),
-        allow_repeats=True
+        allow_identical=True
     )
     actual = [sorted(s) for s in temp]
     print(actual)
     assert len(actual) == len(expected)
     assert set(''.join(str(x)) for x in actual) == set(''.join(str(x)) for x in expected)
+
+
+def test_constrained_powerset_dont_allow_repeats() -> None:
+    note_list = [
+        notes.Note('C', 0),
+        notes.Note('E', 0),
+        notes.Note('G', 0),
+        notes.Note('C', 1),
+    ]
+    expected = [
+        [notes.Note.from_string(s) for s in ['C0', 'E0']],
+        [notes.Note.from_string(s) for s in ['E0', 'C1']],
+        [notes.Note.from_string(s) for s in ['C0', 'E0', 'G0']],
+        [notes.Note.from_string(s) for s in ['E0', 'G0', 'C1']],
+    ]
+    temp = notes.constrained_powerset(
+        note_list, max_len=3,
+        required_notes=notes.note_set([notes.Note('C', 0), notes.Note('E', 0)]),
+        allow_repeats=False
+    )
+    actual = [sorted(s) for s in temp]
+    print(actual)
+    assert len(actual) == len(expected)
+    assert set(''.join(str(x)) for x in actual) == set(''.join(str(x)) for x in expected)
+
+
+@pytest.mark.parametrize('max_notes', [3, 4, 5, 6])
+def test_get_all_chords_2(max_notes: int) -> None:
+    c = notes.ChordName('C')
+    expected = [
+        notes.Chord.from_string('C0,E0,G0'),
+        notes.Chord.from_string('C0,E0,G1'),
+        notes.Chord.from_string('C0,E1,G0'),
+        notes.Chord.from_string('C0,E1,G1'),
+        notes.Chord.from_string('C1,E1,G1'),
+    ]
+    actual = c.get_all_chords_refactor(upper=notes.Note('G', 1), max_notes=max_notes, allow_repeats=False)
+    assert set(actual) == set(expected)
+
+
+def test_get_all_chords_2_allow_repeats() -> None:
+    c = notes.ChordName('C')
+    expected = [
+        notes.Chord.from_string('C0,E0,G0'),
+        notes.Chord.from_string('C0,E0,G1'),
+        notes.Chord.from_string('C0,E1,G0'),
+        notes.Chord.from_string('C0,E1,G1'),
+        notes.Chord.from_string('C1,E1,G1'),
+        notes.Chord.from_string('C0,E0,G0,C1'),
+        notes.Chord.from_string('C0,E0,G1,C1'),
+        notes.Chord.from_string('C0,E1,G0,C1'),
+        notes.Chord.from_string('C0,E1,G1,C1'),
+        notes.Chord.from_string('C0,E0,G0,E1'),
+        notes.Chord.from_string('C0,E0,G1,E1'),
+        notes.Chord.from_string('C0,E1,G0,G1'),
+        notes.Chord.from_string('C0,E0,G0,G1'),
+    ]
+    actual = c.get_all_chords_refactor(upper=notes.Note('G', 1), max_notes=4, allow_repeats=True)
+    assert set(actual) == set(expected)
+
+
+def test_get_all_chords_2_allow_identical() -> None:
+    c = notes.ChordName('C')
+    expected = [
+        notes.Chord.from_string('C0,E0,G0'),
+        notes.Chord.from_string('C0,E0,G1'),
+        notes.Chord.from_string('C0,E1,G0'),
+        notes.Chord.from_string('C0,E1,G1'),
+        notes.Chord.from_string('C1,E1,G1'),
+
+        notes.Chord.from_string('C0,E0,G0,C1'),
+        notes.Chord.from_string('C0,E0,G1,C1'),
+        notes.Chord.from_string('C0,E1,G0,C1'),
+        notes.Chord.from_string('C0,E1,G1,C1'),
+        notes.Chord.from_string('C0,E0,G0,E1'),
+        notes.Chord.from_string('C0,E0,G1,E1'),
+        notes.Chord.from_string('C0,E1,G0,G1'),
+        notes.Chord.from_string('C0,E0,G0,G1'),
+
+        notes.Chord.from_string('C0,E0,G0,C0'),
+        notes.Chord.from_string('C0,E0,G1,C0'),
+        notes.Chord.from_string('C0,E1,G0,C0'),
+        notes.Chord.from_string('C0,E1,G1,C0'),
+        notes.Chord.from_string('C0,E0,G0,E0'),
+        notes.Chord.from_string('C0,E0,G1,E0'),
+        notes.Chord.from_string('C0,E1,G0,G0'),
+        notes.Chord.from_string('C0,E0,G0,G0'),
+        notes.Chord.from_string('C0,E1,G1,G1'),
+        notes.Chord.from_string('C1,C1,E1,G1'),
+        notes.Chord.from_string('C0,E0,G1,G1'),
+        notes.Chord.from_string('C1,E1,E1,G1'),
+        notes.Chord.from_string('C0,E1,E1,G1'),
+        notes.Chord.from_string('C0,G0,E1,E1'),
+        notes.Chord.from_string('C1,E1,G1,G1'),
+    ]
+    actual = c.get_all_chords_refactor(
+        upper=notes.Note('G', 1), max_notes=4,
+        allow_repeats=True, allow_identical=True
+    )
+    assert set(actual) == set(expected)

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -615,3 +615,33 @@ def test_constrained_powerset_different_required_notes() -> None:
     print(actual)
     assert len(actual) == len(expected)
     assert set(''.join(str(x)) for x in actual) == set(''.join(str(x)) for x in expected)
+
+
+def test_constrained_powerset_allow_repeats() -> None:
+    note_list = [
+        notes.Note('C', 0),
+        notes.Note('E', 0),
+        notes.Note('G', 0),
+        notes.Note('C', 1),
+    ]
+    expected = [
+        [notes.Note.from_string(s) for s in ['C0', 'E0']],
+        [notes.Note.from_string(s) for s in ['E0', 'C1']],
+        [notes.Note.from_string(s) for s in ['C0', 'C0', 'E0']],
+        [notes.Note.from_string(s) for s in ['C0', 'E0', 'E0']],
+        [notes.Note.from_string(s) for s in ['C0', 'E0', 'C1']],
+        [notes.Note.from_string(s) for s in ['E0', 'E0', 'C1']],
+        [notes.Note.from_string(s) for s in ['E0', 'C1', 'C1']],
+        [notes.Note.from_string(s) for s in ['C0', 'E0', 'G0']],
+        [notes.Note.from_string(s) for s in ['E0', 'G0', 'C1']],
+    ]
+    temp = notes.constrained_powerset(
+        note_list,
+        max_len=3,
+        required_notes=notes.note_set([notes.Note('C', 0), notes.Note('E', 0)]),
+        allow_repeats=True
+    )
+    actual = [sorted(s) for s in temp]
+    print(actual)
+    assert len(actual) == len(expected)
+    assert set(''.join(str(x)) for x in actual) == set(''.join(str(x)) for x in expected)


### PR DESCRIPTION
A previous optimization (#21) significantly improved the calc of computing all valid guitar fingering positions for a set of chord voicings. This futher improves by:
- improve the calc that computes the set of chord voicings (previously, it searched a lot of options that were either redundant or invalid)
- (optionally) reduces the size of the set of chord voicings (previously, this defaulted to allowing identical notes, which blows up the combinatoric space)

The main helper for this is the `constrained_powerset` function, which adds the ability to generate a powerset of notes subject to constraints like "no repeated notes" or "len(set) <= n".

**Current**
```
(music) joe ~/PycharmProjects/music [main] $ python demo.py --name G7 -r -n 0
You input the chord: G7
There are 43 playable guitar positions (out of 55460 possible) for a guitar tuned to standard.
(Computed in 1.85 seconds)
```

**New** (identical output)
```
(music) joe ~/PycharmProjects/music [jp-optimize-chord-set] $ python demo.py --name G7 -r -i -n 0   
You input the chord: G7
There are 43 playable guitar positions (out of 55460 possible) for a guitar tuned to standard.
(Computed in 1.05 seconds)
```

**New** (reduced output)
```
(music) joe ~/PycharmProjects/music [jp-optimize-chord-set] $ python demo.py --name G7 -r -n 0   
You input the chord: G7
There are 40 playable guitar positions (out of 19516 possible) for a guitar tuned to standard.
(Computed in 0.33 seconds)
```
