### PR TITLE
Allow different cardinality for chord and guitar position motion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,13 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "flask>=3.0.3",
+    "numpy<2",
+    "scipy>=1.13.1",
 ]
 
 [project.optional-dependencies]
 media = [
     "matplotlib>=3.9.2",
-    "numpy<2",
 ]
 test = [
     "setuptools",

--- a/src/music/graph.py
+++ b/src/music/graph.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Hashable
+from typing import Hashable, Optional
 
 import numpy as np
 from scipy.optimize import linear_sum_assignment
@@ -47,12 +47,13 @@ class Graph:
         return list(reversed(trajectory))
 
 
-def assign(cost_matrix: np.ndarray) -> list[int]:
+def assign(cost_matrix: np.ndarray, assign_surplus: bool = True) -> list[Optional[int]]:
     """
     Solve the assignment problem given an input cost_matrix of shape (m, n) with m >= n.
     If the cost matrix is not square, the general problem will be solved first
     (the n rows that optimize the problem will be assigned)
     and the surplus rows will then be assigned to their lowest cost column (thus duplicating some column assignments)
+    if `assign_surplus` is True, or otherwise will be assigned `None`
     """
     if cost_matrix.shape[0] < cost_matrix.shape[1]:
         raise ValueError('`cost_matrix` cannot have more columns than rows')
@@ -60,5 +61,5 @@ def assign(cost_matrix: np.ndarray) -> list[int]:
     surplus = set(range(cost_matrix.shape[0])) - set(assignments[:, 0])
     assignments = assignments.tolist()
     for s in surplus:
-        assignments.append([s, cost_matrix[s, :].argmin()])
-    return [col for _, col  in sorted(assignments)]
+        assignments.append([s, cost_matrix[s, :].argmin() if assign_surplus else None])
+    return [col for _, col in sorted(assignments)]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -30,3 +30,16 @@ def test_graph() -> None:
 def test_assign(cost_matrix, expected) -> None:
     actual = graph.assign(np.array(cost_matrix))
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'cost_matrix,expected',
+    [
+        ([[3, 1, 2], [1, 2, 3], [3, 2, 1]], [1, 0, 2]),
+        ([[3, 1, 2], [1, 2, 3], [3, 2, 1], [0, 100, 50]], [1, None, 2, 0]),
+        ([[3, 1, 2], [1, 2, 3], [1, 1, 0], [3, 2, 1], [0, 100, 50]], [1, None, 2, None, 0]),
+    ]
+)
+def test_assign_without_surplus(cost_matrix, expected) -> None:
+    actual = graph.assign(np.array(cost_matrix), assign_surplus=False)
+    assert actual == expected

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,6 +1,9 @@
 
 from music import graph
 
+import numpy as np
+import pytest
+
 
 def test_graph() -> None:
     nodes = ['a', 'b', 'c', 'd']
@@ -13,4 +16,17 @@ def test_graph() -> None:
     g = graph.Graph(nodes=nodes, edges=edges)
     expected = ['a', 'c', 'd']
     actual = g.shortest_path('a', 'd')
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'cost_matrix,expected',
+    [
+        ([[3, 1, 2], [1, 2, 3], [3, 2, 1]], [1, 0, 2]),
+        ([[3, 1, 2], [1, 2, 3], [3, 2, 1], [0, 100, 50]], [1, 0, 2, 0]),
+        ([[3, 1, 2], [1, 2, 3], [1, 1, 0], [3, 2, 1], [0, 100, 50]], [1, 0, 2, 2, 0]),
+    ]
+)
+def test_assign(cost_matrix, expected) -> None:
+    actual = graph.assign(np.array(cost_matrix))
     assert actual == expected

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -936,8 +936,8 @@ def test_audio_from_chord_list() -> None:
 @pytest.mark.parametrize(
     'p1,p2,expected',
     [
-        ({'A': 2, 'G': 2}, {'A': 3, 'B': 3}, 2),
-        ({'A': 2, 'G': 2, 'B': 3}, {'A': 3, 'B': 3}, 2),
+        ({'A': 2, 'G': 2}, {'A': 3, 'B': 3}, 3),
+        ({'A': 2, 'G': 2, 'B': 3}, {'A': 3, 'B': 3}, 1),
         ({}, {'A': 3, 'B': 3}, 0),
     ]
 )

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -880,6 +880,22 @@ def test_semitone_distance() -> None:
     assert c2.semitone_distance(c1) == 4
 
 
+def test_semitone_distance_different_cardinality() -> None:
+    c1 = music.Chord([
+        music.Note('C', 3),
+        music.Note('F', 3),
+        music.Note('A', 3)
+    ])
+    c2 = music.Chord([
+        music.Note('C', 3),
+        music.Note('E', 3),
+        music.Note('G', 3),
+        music.Note('Bb', 3),
+    ])
+    assert c1.semitone_distance(c2) == 4
+    assert c2.semitone_distance(c1) == 4
+
+
 def test_voice_leading() -> None:
     cp = music.ChordProgression([
         music.ChordName(n) for n in ['Em7', 'A7', 'Dm7', 'G7', 'CM7']]


### PR DESCRIPTION
Prior to this point, computing optimal voice leading between chords with different cardinality of voices would result in an error, and optimal guitar positions between chords with different number of fretted strings didn't work correctly. This PR updates both of these using a new `graph.assign` utility. This solves the [assignment problem](https://en.wikipedia.org/wiki/Assignment_problem) (in general, the unbalanced version for a cost matrix of dimension M x N with M >= N):
- the optimal matching between N pairs is first computed
- if `assign_surplus` is true, then the remaining M - N items are assigned on the basis of least cost
- the function returns a list of length M, where each value is the index of the matched pair

This function is then used to identify the cost for both applications:
- for voice leading, the cost of moving from Chord 1 to 2 is just the sum of semitone motion of each voice (in this case, the chord with the lower cardinality of voices "doubles" one or more voices)
- for fingering positions, the cost of moving from position 1 to 2 is the sum of Manhattan distance of each fretted note (where moving to or from unfretted notes assumes zero cost)