### PR TITLE
Add finger numbers to positions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "music"
-version = "1.3.0"
+version = "1.4.0"
 description = "Helper tools for music"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/music/cli.py
+++ b/src/music/cli.py
@@ -38,7 +38,7 @@ def guitar_positions(args: argparse.Namespace):
     if args.top_n:
         print(f'Here are the top {args.top_n}:')
     for p in positions:
-        print('\n' + '\n'.join(p.printable())) if args.graphical else print(p)
+        print('\n' + '\n'.join(p.printable(fingers=args.fingers))) if args.graphical else print(p)
 
 
 def guitar_optimal_progression(args: argparse.Namespace):
@@ -48,7 +48,7 @@ def guitar_optimal_progression(args: argparse.Namespace):
     print('The optimal positions for this progression are:')
     for chord, position in zip(args.chords, result):
         print(f'{chord}')
-        print('\n'.join(position.printable())) if args.graphical else print(position)
+        print('\n'.join(position.printable(fingers=args.fingers))) if args.graphical else print(position)
 
 
 def voice_leading(args: argparse.Namespace):
@@ -86,6 +86,10 @@ def main() -> None:
     guitar_positions_parser.add_argument(
         '--max-fret-span', '-f', type=int, default=music.DEFAULT_MAX_FRET_SPAN,
         help='Max fret span to consider playable'
+    )
+    guitar_positions_parser.add_argument(
+        '--fingers', '-F', action='store_true',
+        help='Show which finger to use for each note'
     )
     guitar_positions_parser.add_argument(
         '--allow-repeats', '-r', action='store_true',
@@ -126,6 +130,10 @@ def main() -> None:
     guitar_optimal_progression_parser.add_argument(
         '--graphical', '-g', action='store_true',
         help='Show ASCII art for guitar positions'
+    )
+    guitar_optimal_progression_parser.add_argument(
+        '--fingers', '-F', action='store_true',
+        help='Show which finger to use for each note'
     )
     guitar_optimal_progression_parser.add_argument(
         '--allow-repeats', '-r', action='store_true',

--- a/src/music/music.py
+++ b/src/music/music.py
@@ -936,7 +936,7 @@ class GuitarPosition:
             all(self_val == other.positions_dict[key] for key, self_val in self.positions_dict.items())
         )
 
-    def printable(self) -> list[str]:
+    def printable(self, fingers: bool = False) -> list[str]:
         """
         Given a chord position, return ASCII art for the position; each line is an item of the list
         (e.g., you can `print('\n'.join(position.printable()))`)
@@ -944,11 +944,11 @@ class GuitarPosition:
         rows = []
         widest_name = max(len(str(string)) for string in self.guitar.string_names)
         for i, string in reversed(list(enumerate(self.guitar.string_names))):
-            fret_marker = '-T-' if string == self.guitar.string_names[0] and self.use_thumb else '-@-'
             left_padding = ' ' * (widest_name - len(str(string)))
             frets = ['---'] * self.fret_span
             fret = self.positions_dict.get(string, -1)
             if fret > 0:
+                fret_marker = f'-{self.fingers_dict[string]}-' if fingers else '-@-'
                 frets[fret - self.lowest_fret] = fret_marker
                 ring_status = ' '
             else:

--- a/src/music/templates/guitar_chord_progression_input.html
+++ b/src/music/templates/guitar_chord_progression_input.html
@@ -18,6 +18,10 @@
                value="true"></input>
         <label for="allow_repeats"> Allow repeated chord tones</label><br>
         <br>
+        <input type="checkbox" id="show_fingers" name="show_fingers"
+               value="true"></input>
+        <label for="show_fingers"> Show recommended finger to use for each note</label><br>
+        <br>
         <br>
         <button type="submit">Submit</button>
     </form>

--- a/src/music/templates/guitar_positions_input.html
+++ b/src/music/templates/guitar_positions_input.html
@@ -54,6 +54,10 @@
         <label for="allow_identical"> Allow identical (same octave) chord tones<br>
             (Warning, this may increase compute time)</label><br>
         <br>
+        <input type="checkbox" id="show_fingers" name="show_fingers"
+               value="true"></input>
+        <label for="show_fingers"> Show recommended finger to use for each note</label><br>
+        <br>
         <input type="checkbox" id="allow_thumb" name="allow_thumb"
                value="true" checked></input>
         <label for="allow_thumb"> Allow positions requiring thumb</label><br>

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -957,3 +957,33 @@ def test_position_motion_distance(p1: dict[str, int], p2: dict[str, int], expect
 def test_optimal_progression(prog: list[str]) -> None:
     cp = music.ChordProgression([music.ChordName(n) for n in prog])
     cp.optimal_guitar_positions()
+
+
+@pytest.mark.parametrize(
+    'positions,expected',
+    [
+        (
+            {'A': 3, 'D': 2, 'G': 0, 'B': 1, 'e': 0},
+            {'A': '3', 'D': '2', 'B': '1'}
+        ),
+        (
+            {'E': 0, 'A': 2, 'D': 2, 'G': 1, 'B': 0, 'e': 0},
+            {'A': '2', 'D': '3', 'G': '1'}
+        ),
+        (
+            {'E': 3, 'A': 2, 'D': 0, 'G': 0, 'B': 3, 'e': 3},
+            {'E': '2', 'A': '1', 'B': '3', 'e': '4'},
+        ),
+        (
+            {'E': 3, 'D': 3, 'G': 4, 'B': 3, 'e': 4},
+            {'E': 'T', 'D': '1', 'G': '3', 'B': '2', 'e': '4'},
+        ),
+        (
+            {'E': 3, 'A': 5, 'D': 5, 'G': 4, 'B': 3, 'e': 3},
+            {'E': '1', 'A': '3', 'D': '4', 'G': '2', 'B': '1', 'e': '1'},
+        ),
+    ]
+)
+def test_fingers_dict(positions: dict[str, int], expected: dict[str, str]) -> None:
+    positions = music.GuitarPosition(positions)
+    assert positions.fingers_dict == expected

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -185,6 +185,21 @@ def test_print() -> None:
     assert actual == expected
 
 
+def test_print_with_fingers() -> None:
+    position = music.GuitarPosition({'A': 2, 'D': 2})
+    expected = [
+        "e x|---|",
+        "B x|---|",
+        "G x|---|",
+        "D  |-2-|",
+        "A  |-1-|",
+        "E x|---|",
+        "    2fr",
+    ]
+    actual = position.printable(fingers=True)
+    assert actual == expected
+
+
 def test_print_more_complex() -> None:
     open_d = {"D": "D2", "A": "A2", "d": "D3", "F#": "F#3", "a": "A3", "dd": "D4"}
     guitar = music.Guitar(tuning={
@@ -234,6 +249,17 @@ def test_print_barre() -> None:
     ]
     actual = position.printable()
     assert actual == expected
+    expected = [
+        "e  |-1-|---|---|",
+        "B  |-|-|---|-3-|",
+        "G  |-|-|---|---|",
+        "D  |-|-|---|-2-|",
+        "A  |-1-|---|---|",
+        "E x|---|---|---|",
+        "    10fr",
+    ]
+    actual = position.printable(fingers=True)
+    assert actual == expected
 
 
 def test_no_open_strings_along_barre() -> None:
@@ -245,22 +271,22 @@ def test_no_open_strings_along_barre() -> None:
         "G  |---|---|---|---|-@-|",
         "D  |---|---|-@-|---|---|",
         "A x|---|---|---|---|---|",
-        "E  |-T-|---|---|---|---|",
+        "E  |-@-|---|---|---|---|",
         "    3fr",
     ]
     assert position.printable() == expected
     position = music.GuitarPosition({"E": 3, "A": 0, "D": 5, "G": 7, "B": 3, "e": 7})
     assert not position.barre
     expected = [
-        "e  |---|---|---|---|-@-|",
-        "B  |-@-|---|---|---|---|",
-        "G  |---|---|---|---|-@-|",
-        "D  |---|---|-@-|---|---|",
+        "e  |---|---|---|---|-4-|",
+        "B  |-1-|---|---|---|---|",
+        "G  |---|---|---|---|-3-|",
+        "D  |---|---|-2-|---|---|",
         "A o|---|---|---|---|---|",
         "E  |-T-|---|---|---|---|",
         "    3fr",
     ]
-    assert position.printable() == expected
+    assert position.printable(fingers=True) == expected
 
 @pytest.mark.parametrize(
     'string',
@@ -540,10 +566,20 @@ def test_thumb_position_not_barre() -> None:
         "G  |---|-@-|---|---|",
         "D  |-@-|---|---|---|",
         "A  |---|---|-@-|---|",
-        "E  |-T-|---|---|---|",
+        "E  |-@-|---|---|---|",
         "    3fr",
     ]
     assert position.printable() == expected
+    expected = [
+        "e x|---|---|---|---|",
+        "B  |---|---|---|-4-|",
+        "G  |---|-2-|---|---|",
+        "D  |-1-|---|---|---|",
+        "A  |---|---|-3-|---|",
+        "E  |-T-|---|---|---|",
+        "    3fr",
+    ]
+    assert position.printable(fingers=True) == expected
 
 
 def test_constrained_powerset_same_len() -> None:


### PR DESCRIPTION
This adds a `--fingers, -F` option to the CLI and a `show_fingers` box to the app which, for graphical output of chord fingerings, shows the recommended finger to use for each fretted note. The basic heuristic is go from index to pinky as frets move higher up the fretboard, and for multiple notes on the same fret, from lower to higher strings. 

Sample output:

```
$ uv run music-cli guitar-positions --name G7 -n 5 --fingers --graphical -r
You input the chord: G7
There are 17 playable voicings and 17 guitar positions (out of 19516 possible) for a guitar tuned to standard.
Here are the top 5:

e  |---|-4-|
B x|---|---|
G  |---|-3-|
D  |-1-|---|
A  |---|-2-|
E x|---|---|
    9fr

e x|---|---|
B  |---|-4-|
G o|---|---|
D  |---|-3-|
A  |-1-|---|
E  |---|-2-|
    2fr

e  |---|---|-4-|
B  |---|-2-|---|
G  |---|---|-3-|
D  |-1-|---|---|
A x|---|---|---|
E x|---|---|---|
    5fr

e  |-1-|---|---|
B  |-|-|---|-3-|
G  |-|-|---|---|
D  |-|-|---|-2-|
A  |-1-|---|---|
E x|---|---|---|
    10fr

e  |-1-|---|---|
B  |-|-|---|---|
G  |-|-|-2-|---|
D  |-|-|---|---|
A  |-|-|---|-3-|
E  |-1-|---|---|
    3fr
```
