### PR TITLE
Consider finger motion in optimal guitar fingering progression

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,11 +243,14 @@ A longer term goal will be to eliminate circular dependencies from the module.
 - [x] Add audio
 - [x] Voice leading
 - [x] Optimal guitar chords
-- [ ] Add more guitar options for chord progression
+- [x] Add more guitar options for chord progression
+- [x] Better input for specifying tuning
+- [x] Which fingers to use
+- [x] Improve cost function for position movement
 - [ ] Sort on different metrics
-- [ ] Better input for specifying tuning
+- [ ] Refactor CLI tests to be exhaustive
+- [ ] Test on other python versions
+- [ ] Refactor app to DRY out
 - [ ] Remove circular dependencies
-- [ ] Which fingers to use
-- [ ] Improve cost function for position movement
 - [ ] Deploy on AWS
 - [ ] Request logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "music"
-version = "1.5.0"
+version = "1.6.0"
 description = "Helper tools for music"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/music/app.py
+++ b/src/music/app.py
@@ -229,7 +229,9 @@ def guitar_chord_progression_display(
     )
     allow_repeats_: bool = escape(allow_repeats).split('=')[1] == 'true'
     show_fingers_: bool = escape(show_fingers).split('=')[1] == 'true'
-    opt_positions = chord_progression.optimal_guitar_positions(allow_repeats=allow_repeats_)
+    opt_positions = chord_progression.optimal_guitar_positions(
+        allow_repeats=allow_repeats_, respect_fingers=show_fingers_
+    )
     opt_chords = [p.chord for p in opt_positions]
     if music.media_installed and opt_chords:
         audio = reduce(add, (chord.to_audio(sample_rate=SAMPLE_RATE, duration=NOTE_DURATION) for chord in opt_chords))

--- a/src/music/app.py
+++ b/src/music/app.py
@@ -281,7 +281,7 @@ def guitar_chord_progression_display(
     elapsed_time = f'{(time.time() - t1):.2f}'
     return render_template(
         'guitar_chord_progression_display.html',
-        chords=chords_string, positions=positions_printable, elapsed_time=elapsed_time
+        chords=chords_string, tuning=tuning_, positions=positions_printable, elapsed_time=elapsed_time
     )
 
 

--- a/src/music/cli.py
+++ b/src/music/cli.py
@@ -44,7 +44,7 @@ def guitar_positions(args: argparse.Namespace):
 def guitar_optimal_progression(args: argparse.Namespace):
     print(f'You input the chord progression: {args.chords}')
     cp = music.ChordProgression([music.ChordName(n) for n in args.chords])
-    result = cp.optimal_guitar_positions(allow_repeats=args.allow_repeats)
+    result = cp.optimal_guitar_positions(allow_repeats=args.allow_repeats, respect_fingers=args.fingers)
     print('The optimal positions for this progression are:')
     for chord, position in zip(args.chords, result):
         print(f'{chord}')

--- a/src/music/cli.py
+++ b/src/music/cli.py
@@ -44,7 +44,10 @@ def guitar_positions(args: argparse.Namespace):
 def guitar_optimal_progression(args: argparse.Namespace):
     print(f'You input the chord progression: {args.chords}')
     cp = music.ChordProgression([music.ChordName(n) for n in args.chords])
-    result = cp.optimal_guitar_positions(allow_repeats=args.allow_repeats, respect_fingers=args.fingers)
+    guitar = music.Guitar(tuning_name=args.tuning_name, tuning=args.tuning)
+    result = cp.optimal_guitar_positions(
+        guitar=guitar, allow_repeats=args.allow_repeats, respect_fingers=args.fingers
+    )
     print('The optimal positions for this progression are:')
     for chord, position in zip(args.chords, result):
         print(f'{chord}')
@@ -145,6 +148,17 @@ def main() -> None:
     guitar_optimal_progression_parser.add_argument(
         '--allow-repeats', '-r', action='store_true',
         help='Allow chord tones to appear more than once (different octaves)'
+    )
+    guitar_optimal_progression_parser.add_argument(
+        '--tuning-name', '-t', type=str, default=None,
+        help='Name of alternate tuning', choices=list(music.Guitar.TUNINGS.keys())
+    )
+    guitar_optimal_progression_parser.add_argument(
+        '--tuning', type=music.Guitar.parse_tuning, default=None,
+        help=(
+            'A json dict or comma/semicolon separated list specifying a custom guitar tuning, '
+            'e.g.: {"D": "D2", "A": "A2", ...} or D,D2;A,A2;...'
+        )
     )
     guitar_optimal_progression_parser.set_defaults(func=guitar_optimal_progression)
 

--- a/src/music/music.py
+++ b/src/music/music.py
@@ -554,7 +554,12 @@ class ChordProgression:
             motions = sorted(motions, key=lambda x: x['motion'])
             return motions[0]['progression']
 
-    def optimal_guitar_positions(self, guitar: Optional['Guitar'] = None, allow_repeats: bool = False) -> list['GuitarPosition']:
+    def optimal_guitar_positions(
+            self,
+            guitar: Optional['Guitar'] = None,
+            allow_repeats: bool = False,
+            respect_fingers: bool = False,
+    ) -> list['GuitarPosition']:
         guitar = guitar or Guitar()
         positions = [
             get_all_guitar_positions_for_chord_name(
@@ -585,7 +590,11 @@ class ChordProgression:
         for i, p in enumerate(positions[:-1]):
             p_next = positions[i + 1]
             for start, end in product(p, p_next):
-                edge = graph.Edge(start=(i, start), end=(i + 1, end), weight=start.motion_distance(end))
+                edge = graph.Edge(
+                    start=(i, start),
+                    end=(i + 1, end),
+                    weight=start.motion_distance(end, respect_fingers=respect_fingers)
+                )
                 edges.append(edge)
         edges = initial_edges + edges + terminal_edges
         g = graph.Graph(nodes=nodes, edges=edges)

--- a/src/music/music.py
+++ b/src/music/music.py
@@ -559,12 +559,17 @@ class ChordProgression:
             guitar: Optional['Guitar'] = None,
             allow_repeats: bool = False,
             respect_fingers: bool = False,
+            allow_identical: bool = False,
+            allow_thumb: bool = True,
     ) -> list['GuitarPosition']:
         guitar = guitar or Guitar()
         positions = [
             get_all_guitar_positions_for_chord_name(
-                chord_name=chord, guitar=guitar,
-                allow_repeats=allow_repeats, allow_identical=False
+                chord_name=chord,
+                guitar=guitar,
+                allow_repeats=allow_repeats,
+                allow_identical=allow_identical,
+                allow_thumb=allow_thumb,
             )
             for chord in self.chords
         ]

--- a/src/music/templates/guitar_chord_progression_display.html
+++ b/src/music/templates/guitar_chord_progression_display.html
@@ -9,7 +9,7 @@
     <br>
     <img src="/static/temp.png"></img>
     <br>
-    For a guitar tuned to standard, the optimal positions are:
+    For a guitar tuned to {{ tuning }}, the optimal positions are:
 </p>
 
 {% autoescape false %}

--- a/src/music/templates/guitar_chord_progression_input.html
+++ b/src/music/templates/guitar_chord_progression_input.html
@@ -21,7 +21,7 @@
             <option value="drop_d">Drop D</option>
             <option value="open_d">Open D</option>
             <option value="open_g">Open G</option>
-            <option value="open_e">Open E</option>
+            <option value="open_a">Open A</option>
             <option value="custom">Custom</option>
         </select>
         <br>

--- a/src/music/templates/guitar_chord_progression_input.html
+++ b/src/music/templates/guitar_chord_progression_input.html
@@ -14,13 +14,41 @@
                value="{{ request.form['chords'] }}"></input>
         <br>
         <p><b>Optional Parameters</b></p>
+        <label for="tuning_name">Tuning (default Standard)</label>
+        <br>
+        <select name="tuning_name" id="tuning_name">
+            <option value="standard">Standard</option>
+            <option value="drop_d">Drop D</option>
+            <option value="open_d">Open D</option>
+            <option value="open_g">Open G</option>
+            <option value="open_e">Open E</option>
+            <option value="custom">Custom</option>
+        </select>
+        <br>
+        <br>
+        <label for="tuning">(Optional) Custom Guitar Tuning</label>
+        <br>
+        <input type="text" name="tuning" id="tuning"
+               placeholder='E,E2;A,A2;...'
+               value="{{ request.form['tuning'] }}"></input>
+        <br>
+        <br>
         <input type="checkbox" id="allow_repeats" name="allow_repeats"
                value="true"></input>
         <label for="allow_repeats"> Allow repeated chord tones</label><br>
         <br>
+        <input type="checkbox" id="allow_identical" name="allow_identical"
+               value="true"></input>
+        <label for="allow_identical"> Allow identical (same octave) chord tones<br>
+            (Warning, this may increase compute time)</label><br>
+        <br>
         <input type="checkbox" id="show_fingers" name="show_fingers"
                value="true"></input>
         <label for="show_fingers"> Show recommended finger to use for each note</label><br>
+        <br>
+        <input type="checkbox" id="allow_thumb" name="allow_thumb"
+               value="true" checked></input>
+        <label for="allow_thumb"> Allow positions requiring thumb</label><br>
         <br>
         <br>
         <button type="submit">Submit</button>

--- a/src/music/templates/guitar_positions_input.html
+++ b/src/music/templates/guitar_positions_input.html
@@ -45,7 +45,7 @@
             <option value="drop_d">Drop D</option>
             <option value="open_d">Open D</option>
             <option value="open_g">Open G</option>
-            <option value="open_e">Open E</option>
+            <option value="open_a">Open A</option>
             <option value="custom">Custom</option>
         </select>
         <br>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,8 @@ import pytest
 @pytest.mark.parametrize(
     'args',
     [
-        [], ['-n 3'], ['-f 5'], ['-r'], ['-i'], ['-p'], ['-g']
+        [], ['-n', '3'], ['-f', '5'], ['-r'], ['-i'], ['-p'], ['-g'], ['-F'],
+        ['-t', 'open_g'], ['--tuning', 'DD,D2;A,A2;D,D3;G,G3;B,B3;d,D4']
     ]
 )
 def test_guitar_positions_name(name: str, args: list[str]) -> None:
@@ -25,12 +26,30 @@ def test_guitar_positions_name(name: str, args: list[str]) -> None:
 @pytest.mark.parametrize(
     'args',
     [
-        [], ['-n 3'], ['-f 5'], ['-r'], ['-i'], ['-p'], ['-g']
+        [], ['-n', '3'], ['-f', '5'], ['-r'], ['-i'], ['-p'], ['-g'], ['-F'],
+        ['-t', 'open_g'], ['--tuning', 'DD,D2;A,A2;D,D3;G,G3;B,B3;d,D4']
     ]
 )
 def test_guitar_positions_notes(notes: str, args: list[str]) -> None:
     result = subprocess.run(
         ['music-cli', 'guitar-positions', '--notes', notes, *args],
+        capture_output=True)
+    assert result.returncode == 0
+
+
+@pytest.mark.parametrize(
+    'chords', [['Dm7', 'G7b9', 'CM7']]
+)
+@pytest.mark.parametrize(
+    'args',
+    [
+        [], ['-r'], ['-g'], ['-F'],
+        ['-t', 'open_g'], ['--tuning', 'DD,D2;A,A2;D,D3;G,G3;B,B3;d,D4']
+    ]
+)
+def test_guitar_chord_progression(chords: list[str], args: list[str]) -> None:
+    result = subprocess.run(
+        ['music-cli', 'guitar-chord-progression', '--chords', *chords, *args],
         capture_output=True)
     assert result.returncode == 0
 

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -1030,6 +1030,23 @@ def test_position_motion_distance(p1: dict[str, int], p2: dict[str, int], expect
 
 
 @pytest.mark.parametrize(
+    'p1,p2,expected',
+    [
+        ({'A': 2, 'G': 2}, {'A': 3, 'B': 3}, 3),
+        # Here, we move from second finger on the G string to the B string
+        ({'A': 2, 'G': 2, 'B': 3}, {'A': 3, 'B': 3}, 3),
+        ({}, {'A': 3, 'B': 3}, 0),
+        # # For barre chord, index only costs 1
+        ({'A': 2, 'D': 4, 'G': 2, 'B': 4, 'e': 2}, {'A': 3, 'D': 5, 'G': 3, 'B': 5, 'e': 3}, 3),
+    ]
+)
+def test_position_motion_distance_respect_fingers(p1: dict[str, int], p2: dict[str, int], expected: int) -> None:
+    p1 = music.GuitarPosition(positions=p1)
+    p2 = music.GuitarPosition(positions=p2)
+    assert p1.motion_distance(p2, respect_fingers=True) == expected
+
+
+@pytest.mark.parametrize(
     'prog', [
         ['Dm7', 'G7', 'CM7'],
         ['Dm7', 'G7b9', 'C'],

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -1046,16 +1046,19 @@ def test_position_motion_distance_respect_fingers(p1: dict[str, int], p2: dict[s
     assert p1.motion_distance(p2, respect_fingers=True) == expected
 
 
+@pytest.mark.parametrize('respect_fingers', [True, False])
 @pytest.mark.parametrize(
     'prog', [
         ['Dm7', 'G7', 'CM7'],
         ['Dm7', 'G7b9', 'C'],
-        ['Dm7#11', 'G7', 'C']
+        ['Dm7#13', 'G7', 'C'],
+        ['Em7', 'A7', 'Dm7', 'G7', 'CM7'],
     ]
 )
-def test_optimal_progression(prog: list[str]) -> None:
+def test_optimal_progression(prog: list[str], respect_fingers: bool) -> None:
     cp = music.ChordProgression([music.ChordName(n) for n in prog])
-    cp.optimal_guitar_positions()
+    actual = cp.optimal_guitar_positions(respect_fingers=respect_fingers)
+    assert  len(actual) == len(prog)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Previously, the chord progression optimal guitar fingerings computed the cost of motion between chords as the total number of strings / frets that needed to move. However, this could result in situations where the "minimal motion" switched from one finger to another. Here, we allow an option to consider minimizing the actual motion of the recommended fingers. (A follow up could be to allow multiple possible fingerings for a given position, rather than just the "recommended" one in isolation, and optimize globally over the progression for the set of _fingerings_ that minimizes the motion).